### PR TITLE
OAuth: форма ввода user_id + поддержка redirect на chat.openai.com (/aip/g-*/oauth/callback)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ REFRESH_PEPPER=CHANGE_ME_TO_ANOTHER_RANDOM_STRING
 # STAS DB bridge
 STAS_API_BASE=https://stas.stravatg.ru
 STAS_API_KEY=PUT_YOUR_STAS_API_KEY_HERE
+SKIP_STAS_VALIDATE=false  # set true in dev to skip user_id validation via STAS
 
 # MCP (Intervals)
 MCP_API_BASE=https://mcp.stravatg.ru/api
@@ -20,3 +21,6 @@ DB_NAME=YOUR_DB_NAME
 DB_USER=YOUR_DB_USER
 DB_PASSWORD=YOUR_DB_PASSWORD
 DB_SSL=false
+
+# Health diagnostics
+HEALTH_USER_ID=0  # optional: echo in /healthz.env.health_user_id (non-secret)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@
 1) Установи Node.js 22 (через nvm)  
 2) Создай `.env` и заполни значения:  
 ```
+
+### Примечания
+
+- Разрешены redirect_uri только на `chat.openai.com` и `chatgpt.com` с путями:
+  - `/aip/api/callback`
+  - `/aip/g-*/oauth/callback` (например, `/aip/g-abc123/oauth/callback`)
+- Параметр `state` из `/oauth/authorize` автоматически прокидывается в редирект.
 PORT=3337
 JWT_SECRET=<set-strong-random>
 REFRESH_PEPPER=<set-strong-random>
@@ -28,6 +35,8 @@ STAS_API_KEY=<stas_key>
 # MCP (Intervals.icu bridge)
 MCP_API_BASE=https://mcp.stravatg.ru/api
 MCP_API_KEY=<mcp_key>
+# Health diagnostics (optional)
+HEALTH_USER_ID=0
 ```
 3) Установи зависимости:
 ```bash
@@ -80,6 +89,21 @@ curl -sS 'http://127.0.0.1:3337/api/icu/activities?days=7' -H "Authorization: Be
 - `POST /oauth/token` (grant_type=authorization_code|refresh_token)
 - `GET /api/me` (Bearer JWT)
 - `ANY /^/api/icu/` (прокси в MCP, требует скоупы: icu для GET, workouts:write для POST/DELETE)
+
+## Health
+
+- `GET /healthz` всегда возвращает единый JSON объект `{ ok, time, stas?, env }`.
+- В блоке `env` присутствуют небезопасные (не секретные) диагностические поля:
+  - `skip_stas_validate` — флаг из `.env` (true/false)
+  - `health_user_id` — значение `HEALTH_USER_ID` из `.env` (число или null)
+
+## Тесты
+
+Запуск минимальных тестов для проверки whitelist редиректов:
+
+```bash
+npm test
+```
 
 ## Деплой (контур)
 

--- a/bin/test_isAllowedRedirect.js
+++ b/bin/test_isAllowedRedirect.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+const { isAllowedRedirect } = require('../lib/redirect');
+
+const cases = [
+  ['https://chatgpt.com/aip/api/callback', true],
+  ['https://chat.openai.com/aip/api/callback?x=1', true],
+  ['https://chatgpt.com/aip/g-abc123/oauth/callback', true],
+  ['https://chatgpt.com/aip/g-xyz/oauth/callback?state=abc', true],
+  ['https://chatgpt.com/aip/g-/oauth/callback', false],
+  ['https://chatgpt.com/aip/g-abc/oauth/callback/extra', false],
+  ['https://example.com/aip/api/callback', false],
+  ['notaurl', false],
+];
+
+let failed = 0;
+for (const [url, expected] of cases) {
+  const actual = isAllowedRedirect(url);
+  if (actual !== expected) {
+    console.error(`FAIL: isAllowedRedirect(${url}) => ${actual}, expected ${expected}`);
+    failed++;
+  }
+}
+
+if (failed === 0) {
+  console.log('All isAllowedRedirect tests passed.');
+  process.exit(0);
+} else {
+  console.error(`${failed} tests failed.`);
+  process.exit(1);
+}

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -1,0 +1,21 @@
+// Redirect whitelist utility
+// Allows only ChatGPT Actions callback URLs
+// Hosts: chat.openai.com, chatgpt.com
+// Paths:
+//  - /aip/api/callback
+//  - /aip/g-<group>/oauth/callback
+function isAllowedRedirect(urlStr) {
+  try {
+    const u = new URL(urlStr);
+    const hostOk = ['chat.openai.com', 'chatgpt.com'].includes(u.hostname);
+    if (!hostOk) return false;
+    const p = u.pathname;
+    if (p === '/aip/api/callback') return true;
+    if (/^\/aip\/g-[^/]+\/oauth\/callback$/.test(p)) return true;
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+module.exports = { isAllowedRedirect };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "start": "node app.js",
     "dev": "NODE_ENV=development node app.js",
-    "migrate": "node ./bin/migrate.js"
+    "migrate": "node ./bin/migrate.js",
+    "test": "node ./bin/test_isAllowedRedirect.js"
   },
   "dependencies": {
     "axios": "^1.7.0",


### PR DESCRIPTION
Что сделано
- /oauth/authorize: если нет user_id → отдаём лёгкую HTML-форму для ввода реального STAS user_id; если есть → сразу обычный 302 с code (+state).
- Валидатор redirect_uri: допускаем chat.openai.com и путь вида /aip/g-*/oauth/callback, помимо chatgpt.com/aip/api/callback.
- Nginx: убран хардкод user_id; /gw/oauth/authorize теперь прозрачный прокси.

Проверка
1) Без user_id: 
   curl -is "https://intervals.stas.run/gw/oauth/authorize?response_type=code&client_id=chatgpt-actions&redirect_uri=<ENCODED_CHAT.OPENAI.COM_CALLBACK>&scope=read%3Ame%20icu%20workouts%3Awrite&state=dbg" 
   → 200 text/html (форма).
2) С user_id:
   curl -is "…&user_id=95192039" | grep -i '^location' 
   → 302 Location: <callback>?code=…&state=dbg
3) Обмен на токен:
   curl --http1.1 -X POST https://intervals.stas.run/gw/oauth/token -u "chatgpt-actions:<CLIENT_SECRET>" \
     -d grant_type=authorization_code -d code=<CODE> -d redirect_uri=<CHAT.OPENAI.COM_CALLBACK>
   → access_token
