### PR TITLE
chore: update Actions/OpenAPI schemas (trainings full support)

### DIFF
--- a/final_oauth_schema.json
+++ b/final_oauth_schema.json
@@ -82,6 +82,18 @@
               "type": "integer",
               "default": 30
             }
+          },
+          {
+            "name": "full",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "1"
+              ]
+            },
+            "description": "If set to \"1\", returns full training payload (includes activity_plan, hr_zone_times, interval_summary, splits_km)."
           }
         ],
         "responses": {
@@ -319,20 +331,51 @@
         }
       }
     },
-    "/api/db/activities_full": {
+    "/trainings": {
       "get": {
-        "summary": "Get user trainings (full payload)",
-        "description": "Returns completed training sessions from local database including large jsonb fields (activity_plan, hr_zone_times, interval_summary, splits_km).",
-        "operationId": "getUserTrainingsFull",
+        "summary": "Load trainings (runs) for a date window",
+        "operationId": "trainingsGet",
+        "description": "Returns an array of trainings for the authenticated user. Use oldest/newest for non-overlapping windows. Use full=1 to request detailed payload.",
         "parameters": [
           {
-            "name": "user_id",
+            "name": "oldest",
             "in": "query",
             "required": true,
             "schema": {
-              "type": "integer"
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
             },
-            "description": "User ID from the system"
+            "description": "Start date (inclusive), YYYY-MM-DD"
+          },
+          {
+            "name": "newest",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            },
+            "description": "End date (exclusive), YYYY-MM-DD"
+          },
+          {
+            "name": "full",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "enum": [
+                    0,
+                    1
+                  ]
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
+            },
+            "description": "If true/1 -> detailed payload"
           },
           {
             "name": "limit",
@@ -343,162 +386,183 @@
               "minimum": 1,
               "maximum": 200
             },
-            "description": "Max items (default 30, max 200)"
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0
-            },
-            "description": "Offset (default 0)"
-          },
-          {
-            "name": "oldest",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            },
-            "description": "Oldest date (YYYY-MM-DD)"
-          },
-          {
-            "name": "newest",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            },
-            "description": "Newest date (YYYY-MM-DD)"
+            "description": "Max items to return (server may cap)"
           }
         ],
         "responses": {
           "200": {
-            "description": "List of training sessions (full payload)",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "trainings": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "date": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "workout_type": {
+                        "type": "string"
+                      },
+                      "distance": {
+                        "type": "string"
+                      },
+                      "user_report": {
+                        "type": "string"
+                      },
+                      "ai_comment": {
+                        "type": "string"
+                      },
+                      "training_load": {
+                        "type": "number"
+                      },
+                      "fitness": {
+                        "type": "number"
+                      },
+                      "fatigue": {
+                        "type": "number"
+                      },
+                      "elevation_gain": {
+                        "type": "number"
+                      },
+                      "intensity": {
+                        "type": "string"
+                      },
+                      "icu_hr_zones": {
+                        "type": "string"
+                      },
+                      "avg_heartrate": {
+                        "type": "number"
+                      },
+                      "max_heartrate": {
+                        "type": "number"
+                      },
+                      "lactate_threshold_hr": {
+                        "type": "number"
+                      },
+                      "moving_time": {
+                        "type": "string"
+                      },
+                      "form": {
+                        "type": "string"
+                      },
+                      "user_id": {
+                        "type": "integer"
+                      },
+                      "pace": {
+                        "type": "string"
+                      },
+                      "activity_name": {
+                        "type": "string"
+                      },
+                      "session_type": {
+                        "oneOf": [
+                          {
                             "type": "string"
                           },
-                          "date": {
-                            "type": "string",
-                            "format": "date-time"
-                          },
-                          "workout_type": {
-                            "type": "string"
-                          },
-                          "distance": {
-                            "type": "string"
-                          },
-                          "user_report": {
-                            "type": "string"
-                          },
-                          "ai_comment": {
-                            "type": "string"
-                          },
-                          "training_load": {
-                            "type": "number"
-                          },
-                          "fitness": {
-                            "type": "number"
-                          },
-                          "fatigue": {
-                            "type": "number"
-                          },
-                          "elevation_gain": {
-                            "type": "number"
-                          },
-                          "intensity": {
-                            "type": "string"
-                          },
-                          "icu_hr_zones": {
-                            "type": "string"
-                          },
-                          "avg_heartrate": {
-                            "type": "number"
-                          },
-                          "max_heartrate": {
-                            "type": "number"
-                          },
-                          "lactate_threshold_hr": {
-                            "type": "number"
-                          },
-                          "moving_time": {
-                            "type": "string"
-                          },
-                          "form": {
-                            "type": "string"
-                          },
-                          "user_id": {
-                            "type": "integer"
-                          },
-                          "pace": {
-                            "type": "string"
-                          },
-                          "activity_name": {
-                            "type": "string"
-                          },
-                          "activity_plan": {
-                            "type": [
-                              "object",
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "hr_zone_times": {
-                            "type": [
-                              "array",
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "interval_summary": {
-                            "type": [
-                              "array",
-                              "null"
-                            ]
-                          },
-                          "splits_km": {
-                            "type": [
-                              "array",
-                              "null"
-                            ]
-                          },
-                          "session_type": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
+                          {
+                            "type": "null"
                           }
-                        }
+                        ]
+                      },
+                      "activity_plan": {
+                        "oneOf": [
+                          {
+                            "type": "object"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "hr_zone_times": {
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "integer"
+                            }
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "number"
+                            }
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "interval_summary": {
+                        "oneOf": [
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "splits_km": {
+                        "oneOf": [
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "km": {
+                                  "type": "number"
+                                },
+                                "pace": {
+                                  "type": "string"
+                                },
+                                "hr": {
+                                  "type": "number"
+                                }
+                              },
+                              "additionalProperties": true
+                            }
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
                       }
                     },
-                    "count": {
-                      "type": "integer"
-                    }
+                    "additionalProperties": true
                   }
                 }
               }
             }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Server error"
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     }
   },

--- a/openapi.actions.json
+++ b/openapi.actions.json
@@ -24,7 +24,7 @@
     }
   ],
   "paths": {
-    "/gw/healthz": {
+    "/healthz": {
       "get": {
         "summary": "Health check",
         "operationId": "healthzGet",
@@ -56,7 +56,7 @@
         "security": []
       }
     },
-    "/gw/version": {
+    "/version": {
       "get": {
         "summary": "Gateway version",
         "operationId": "versionGet",
@@ -88,7 +88,7 @@
         "security": []
       }
     },
-    "/gw/api/db/user_summary": {
+    "/api/db/user_summary": {
       "get": {
         "summary": "Get user summary (user_id inferred from Bearer)",
         "operationId": "dbUserSummaryGet",
@@ -111,78 +111,20 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/gw/api/db/activities": {
-      "get": {
-        "summary": "List user activities",
-        "operationId": "dbActivitiesGet",
-        "parameters": [
-          {
-            "name": "user_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "pattern": "^[0-9]+$"
-            }
-          },
-          {
-            "name": "days",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 365
-            }
-          },
-          {
-            "name": "from",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "to",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Array of activities",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "additionalProperties": true
+                  "additionalProperties": false,
+                  "required": [
+                    "ok",
+                    "user_summary"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "user_summary": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {}
+                    }
                   }
                 }
               }
@@ -194,7 +136,8 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true
+                  "additionalProperties": true,
+                  "properties": {}
                 }
               }
             }
@@ -202,7 +145,7 @@
         }
       }
     },
-    "/gw/icu/events": {
+    "/icu/events": {
       "get": {
         "summary": "Intervals.icu events via gateway (user_id inferred from Bearer)",
         "operationId": "icuEventsGet",
@@ -254,7 +197,8 @@
                   "type": "array",
                   "items": {
                     "type": "object",
-                    "additionalProperties": true
+                    "additionalProperties": true,
+                    "properties": {}
                   }
                 }
               }
@@ -266,7 +210,8 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true
+                  "additionalProperties": true,
+                  "properties": {}
                 }
               }
             }
@@ -274,7 +219,7 @@
         }
       }
     },
-    "/gw/oauth/authorize": {
+    "/oauth/authorize": {
       "get": {
         "summary": "OAuth2 authorize (stubbed)",
         "operationId": "oauthAuthorizeGet",
@@ -339,7 +284,7 @@
         "security": []
       }
     },
-    "/gw/oauth/token": {
+    "/oauth/token": {
       "post": {
         "summary": "OAuth2 token (stub/PKCE)",
         "operationId": "oauthTokenPost",
@@ -423,13 +368,168 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true
+                  "additionalProperties": true,
+                  "properties": {}
                 }
               }
             }
           }
         },
         "security": []
+      }
+    },
+    "/strategy": {
+      "post": {
+        "summary": "Update user strategy text",
+        "operationId": "gwPostStrategy",
+        "description": "Updates public.user.strategy for the authenticated user (uid comes only from Bearer token; user_id in query/body is forbidden).",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "strategy_text": {
+                    "type": "string"
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "strategy_text"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "user_id": {
+                      "type": "integer"
+                    },
+                    "updated_at": {
+                      "type": "string"
+                    },
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "413": {
+            "description": "Payload too large"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          }
+        }
+      }
+    },
+    "/trainings": {
+      "get": {
+        "summary": "Load trainings (runs) for a date window",
+        "operationId": "trainingsGet",
+        "description": "Returns an array of trainings for the authenticated user. Use oldest/newest for non-overlapping windows. Use full=1 to request detailed payload.",
+        "parameters": [
+          {
+            "name": "oldest",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            },
+            "description": "Start date (inclusive), YYYY-MM-DD"
+          },
+          {
+            "name": "newest",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            },
+            "description": "End date (exclusive), YYYY-MM-DD"
+          },
+          {
+            "name": "full",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "enum": [
+                    0,
+                    1
+                  ]
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
+            },
+            "description": "If true/1 -> detailed payload"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200
+            },
+            "description": "Max items to return (server may cap)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": true
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
       }
     }
   }

--- a/openapi.json
+++ b/openapi.json
@@ -1,24 +1,639 @@
 {
-  "bearerAuth": {
-    "type": "http",
-    "scheme": "bearer"
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Intervals/STAS Gateway API",
+    "description": "OAuth-protected gateway for STAS DB and Intervals.icu. user_id extracted from JWT token, no client-side user_id required.",
+    "version": "1.0.0"
   },
-  "components": {
-    "securitySchemes": {
-      "bearerAuth": {
-        "type": "http",
-        "scheme": "bearer"
-      }
+  "servers": [
+    {
+      "url": "https://intervals.stas.run"
     }
-  },
+  ],
   "security": [
     {
       "bearerAuth": []
     }
   ],
-  "servers": [
-    {
-      "url": "https://intervals.stas.run/gw"
+  "paths": {
+    "/gw/api/me": {
+      "get": {
+        "operationId": "getMe",
+        "summary": "Get current user identity from JWT token",
+        "responses": {
+          "200": {
+            "description": "User identity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "user_id": {
+                      "type": "integer"
+                    },
+                    "athlete_id": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/gw/api/db/user_summary": {
+      "get": {
+        "operationId": "getUserSummary",
+        "summary": "Get user summary from STAS DB (user_id from JWT token)",
+        "responses": {
+          "200": {
+            "description": "User summary data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "user_summary": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/gw/api/db/trainings": {
+      "get": {
+        "operationId": "getUserTrainings",
+        "summary": "Get user trainings from STAS DB (user_id from JWT token)",
+        "parameters": [
+          {
+            "name": "days",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 30
+            }
+          },
+          {
+            "name": "full",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "1"
+              ]
+            },
+            "description": "If set to \"1\", returns full training payload (includes activity_plan, hr_zone_times, interval_summary, splits_km)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Training sessions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "trainings": {
+                      "type": "array"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/gw/icu/events": {
+      "get": {
+        "operationId": "getPlannedWorkouts",
+        "summary": "Get planned workouts from Intervals.icu (athlete_id from JWT token)",
+        "parameters": [
+          {
+            "name": "days",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 60
+            }
+          },
+          {
+            "name": "oldest",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "newest",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Planned workouts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "start_date": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      },
+      "post": {
+        "operationId": "createPlannedWorkouts",
+        "summary": "Create planned workouts in Intervals.icu (requires workouts:write scope)",
+        "parameters": [
+          {
+            "name": "dry_run",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
+          },
+          {
+            "name": "external_id_prefix",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "events": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "category": {
+                          "type": "string",
+                          "enum": [
+                            "WORKOUT"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "RUN",
+                            "BIKE",
+                            "SWIM"
+                          ]
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "start_date_local": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Bulk operation result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "dry_run": {
+                      "type": "boolean"
+                    },
+                    "created": {
+                      "type": "integer"
+                    },
+                    "skipped": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/gw/trainings": {
+      "get": {
+        "summary": "Load trainings (runs) for a date window",
+        "operationId": "trainingsGet",
+        "description": "Returns an array of trainings for the authenticated user. Use oldest/newest for non-overlapping windows. Use full=1 to request detailed payload.",
+        "parameters": [
+          {
+            "name": "oldest",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            },
+            "description": "Start date (inclusive), YYYY-MM-DD"
+          },
+          {
+            "name": "newest",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            },
+            "description": "End date (exclusive), YYYY-MM-DD"
+          },
+          {
+            "name": "full",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "description": "If true -> detailed payload"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200
+            },
+            "description": "Max items to return (server may cap)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "date": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "workout_type": {
+                        "type": "string"
+                      },
+                      "distance": {
+                        "type": "string"
+                      },
+                      "user_report": {
+                        "type": "string"
+                      },
+                      "ai_comment": {
+                        "type": "string"
+                      },
+                      "training_load": {
+                        "type": "number"
+                      },
+                      "fitness": {
+                        "type": "number"
+                      },
+                      "fatigue": {
+                        "type": "number"
+                      },
+                      "elevation_gain": {
+                        "type": "number"
+                      },
+                      "intensity": {
+                        "type": "string"
+                      },
+                      "icu_hr_zones": {
+                        "type": "string"
+                      },
+                      "avg_heartrate": {
+                        "type": "number"
+                      },
+                      "max_heartrate": {
+                        "type": "number"
+                      },
+                      "lactate_threshold_hr": {
+                        "type": "number"
+                      },
+                      "moving_time": {
+                        "type": "string"
+                      },
+                      "form": {
+                        "type": "string"
+                      },
+                      "user_id": {
+                        "type": "integer"
+                      },
+                      "pace": {
+                        "type": "string"
+                      },
+                      "activity_name": {
+                        "type": "string"
+                      },
+                      "session_type": {
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "activity_plan": {
+                        "oneOf": [
+                          {
+                            "type": "object"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "hr_zone_times": {
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "integer"
+                            }
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "number"
+                            }
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "interval_summary": {
+                        "oneOf": [
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "splits_km": {
+                        "oneOf": [
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "km": {
+                                  "type": "number"
+                                },
+                                "pace": {
+                                  "type": "string"
+                                },
+                                "hr": {
+                                  "type": "number"
+                                }
+                              },
+                              "additionalProperties": true
+                            }
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    },
+                    "additionalProperties": true
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/gw/strategy": {
+      "post": {
+        "summary": "Update user strategy text",
+        "operationId": "gwPostStrategy",
+        "description": "Updates public.user.strategy for the authenticated user (uid comes only from Bearer token; user_id in query/body is forbidden).",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "strategy_text": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "strategy_text"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "user_id": {
+                      "type": "integer"
+                    },
+                    "bytes": {
+                      "type": "integer"
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
     }
-  ]
+  },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      }
+    },
+    "schemas": {
+      "Training": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "workout_type": {
+            "type": "string"
+          },
+          "distance": {
+            "type": "string"
+          },
+          "training_load": {
+            "type": "number"
+          },
+          "fitness": {
+            "type": "number"
+          },
+          "fatigue": {
+            "type": "number"
+          },
+          "elevation_gain": {
+            "type": "number"
+          },
+          "intensity": {
+            "type": "string"
+          },
+          "user_report": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
 }

--- a/openapi.min.json
+++ b/openapi.min.json
@@ -23,7 +23,7 @@
     }
   ],
   "paths": {
-    "/gw/healthz": {
+    "/healthz": {
       "get": {
         "summary": "Health",
         "responses": {
@@ -50,7 +50,7 @@
         "security": []
       }
     },
-    "/gw/api/db/user_summary": {
+    "/api/db/user_summary": {
       "get": {
         "summary": "User summary (uid from Bearer)",
         "parameters": [
@@ -71,7 +71,21 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true
+                  "additionalProperties": false,
+                  "required": [
+                    "ok",
+                    "user_summary"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "user_summary": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {}
+                    }
+                  }
                 }
               }
             }
@@ -95,7 +109,7 @@
         }
       }
     },
-    "/gw/icu/events": {
+    "/icu/events": {
       "get": {
         "summary": "ICU events (uid from Bearer)",
         "parameters": [
@@ -119,7 +133,8 @@
                   "type": "array",
                   "items": {
                     "type": "object",
-                    "additionalProperties": true
+                    "additionalProperties": true,
+                    "properties": {}
                   }
                 }
               }
@@ -140,6 +155,160 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/strategy": {
+      "post": {
+        "summary": "Update user strategy text",
+        "operationId": "gwPostStrategy",
+        "description": "Updates public.user.strategy for the authenticated user (uid comes only from Bearer token; user_id in query/body is forbidden).",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "strategy_text": {
+                    "type": "string"
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "strategy_text"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "user_id": {
+                      "type": "integer"
+                    },
+                    "updated_at": {
+                      "type": "string"
+                    },
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "413": {
+            "description": "Payload too large"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          }
+        }
+      }
+    },
+    "/trainings": {
+      "get": {
+        "summary": "Load trainings (runs) for a date window",
+        "operationId": "trainingsGet",
+        "description": "Returns an array of trainings for the authenticated user. Use oldest/newest for non-overlapping windows. Use full=1 to request detailed payload.",
+        "parameters": [
+          {
+            "name": "oldest",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            },
+            "description": "Start date (inclusive), YYYY-MM-DD"
+          },
+          {
+            "name": "newest",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            },
+            "description": "End date (exclusive), YYYY-MM-DD"
+          },
+          {
+            "name": "full",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "enum": [
+                    0,
+                    1
+                  ]
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
+            },
+            "description": "If true/1 -> detailed payload"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200
+            },
+            "description": "Max items to return (server may cap)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": true
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Server error"
           }
         }
       }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Schema-only changes, but they rename/reshape several documented endpoints and response payloads, which may break generated clients or integrations relying on the previous OpenAPI contracts.
> 
> **Overview**
> Refreshes the published OpenAPI specs (`openapi.json`, `openapi.actions.json`, `openapi.min.json`, `final_oauth_schema.json`) to better match current gateway routing and payloads.
> 
> Key contract updates: **(1)** normalize several documented paths by removing the `/gw` prefix in the Actions/min specs (e.g. `/healthz`, `/version`, `/api/db/user_summary`, `/icu/events`, `/oauth/*`), **(2)** add a new authenticated `POST /strategy` endpoint, and **(3)** rework trainings documentation by adding a `full` option on `GET /api/db/trainings` and replacing the old “full trainings” endpoint with `GET /trainings` that uses required `oldest`/`newest` date-window params, optional `limit`, and a more explicit (nullable/union) training payload schema plus error responses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc8b4b354807414fa921422dcc613ffc714097e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->