### PR TITLE
Add activity_detail gateway docs and smoke coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ Server-local path: `/home/codex/codex-work/Projects/stas-auth-gateway`.
 
     curl -sS http://127.0.0.1:3337/gw/healthz
 
+Для локальной проверки нового `activity_detail` есть отдельный smoke-скрипт:
+
+    GW_ACTIVITY_DETAIL_TOKEN=... GW_ACTIVITY_DETAIL_TRAINING_ID=... scripts/smoke-gw.sh
+
+По умолчанию эта проверка пропускается, так что реальные production `user_id` не нужны.
+Для быстрой проверки проксирования можно запустить:
+
+    npm run test:db-proxy
+
 ## Systemd / Nginx
 
 Production examples live in `deploy/`.

--- a/openapi.actions.json
+++ b/openapi.actions.json
@@ -100,6 +100,47 @@
         }
       }
     },
+    "/gw/api/db/activity_detail": {
+      "get": {
+        "operationId": "getActivityDetailFromDB",
+        "summary": "Get activity detail from STAS DB",
+        "parameters": [
+          {
+            "name": "training_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "description": "Training id to load details for."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Activity detail payload",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/gw/icu/events": {
       "get": {
         "operationId": "getPlannedWorkoutsGw",

--- a/openapi.min.json
+++ b/openapi.min.json
@@ -95,6 +95,51 @@
         }
       }
     },
+    "/gw/api/db/activity_detail": {
+      "get": {
+        "summary": "Activity detail (uid from Bearer)",
+        "parameters": [
+          {
+            "name": "training_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Activity detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/gw/icu/events": {
       "get": {
         "summary": "ICU events (uid from Bearer)",

--- a/openapi.min.yaml
+++ b/openapi.min.yaml
@@ -67,6 +67,34 @@ paths:
                   error:
                     type: string
                 additionalProperties: true
+  /gw/api/db/activity_detail:
+    get:
+      summary: Activity detail (uid from Bearer)
+      parameters:
+      - name: training_id
+        in: query
+        required: true
+        schema:
+          type: string
+          minLength: 1
+      responses:
+        '200':
+          description: Activity detail
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                additionalProperties: true
   /gw/icu/events:
     get:
       summary: ICU events (uid from Bearer)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -192,6 +192,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /gw/api/db/activity_detail:
+    get:
+      summary: Get activity detail (user_id inferred from Bearer)
+      operationId: dbActivityDetailGet
+      parameters:
+      - name: training_id
+        in: query
+        required: true
+        schema:
+          type: string
+          minLength: 1
+        description: Training id to load details for.
+      responses:
+        '200':
+          description: Activity detail object
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /gw/icu/events:
     get:
       summary: Intervals.icu events via gateway (user_id inferred from Bearer)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "dev": "node server.js"
+    "dev": "node server.js",
+    "test:db-proxy": "node scripts/test-db-proxy.js"
   },
   "keywords": [
     "oauth",

--- a/scripts/smoke-gw.sh
+++ b/scripts/smoke-gw.sh
@@ -1,5 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
-URL="http://127.0.0.1:${PORT:-3340}/gw/debug/echo_auth"
-curl -sS "$URL" -H "Authorization: Bearer invalid" >/dev/null || exit 1
+
+BASE_URL="${GW_BASE_URL:-http://127.0.0.1:${PORT:-3340}}"
+
+curl -sS "${BASE_URL}/gw/debug/echo_auth" -H "Authorization: Bearer invalid" >/dev/null || exit 1
+
+# Optional local-only-by-default check for /gw/api/db/activity_detail.
+# No user_id is required; the gateway infers it from the Bearer token.
+# Enable explicitly:
+#   GW_ACTIVITY_DETAIL_TOKEN=... GW_ACTIVITY_DETAIL_TRAINING_ID=... scripts/smoke-gw.sh
+if [[ -n "${GW_ACTIVITY_DETAIL_TOKEN:-}" && -n "${GW_ACTIVITY_DETAIL_TRAINING_ID:-}" ]]; then
+  encoded_training_id="$(node -e "process.stdout.write(encodeURIComponent(process.argv[1]))" "$GW_ACTIVITY_DETAIL_TRAINING_ID")"
+  curl -sS \
+    "${BASE_URL}/gw/api/db/activity_detail?training_id=${encoded_training_id}" \
+    -H "Authorization: Bearer ${GW_ACTIVITY_DETAIL_TOKEN}" \
+    >/dev/null
+else
+  echo "Skipping optional activity_detail smoke; set GW_ACTIVITY_DETAIL_TOKEN and GW_ACTIVITY_DETAIL_TRAINING_ID to enable." >&2
+fi
+
 exit 0

--- a/scripts/test-db-proxy.js
+++ b/scripts/test-db-proxy.js
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('assert');
+
+process.env.STAS_KEY = process.env.STAS_KEY || 'test-stas-key';
+process.env.STAS_BASE = process.env.STAS_BASE || 'http://stas.local.test';
+
+const upstreamHits = [];
+const originalFetch = global.fetch;
+
+global.fetch = async (url, options = {}) => {
+  upstreamHits.push({
+    url: url.toString(),
+    method: options.method || 'GET',
+    headers: options.headers || {},
+    body: options.body,
+  });
+
+  return {
+    status: 200,
+    headers: {
+      get(name) {
+        return String(name).toLowerCase() === 'content-type' ? 'application/json; charset=utf-8' : null;
+      },
+    },
+    text: async () => JSON.stringify({ ok: true, url: url.toString() }),
+  };
+};
+
+const uidInjectDb = require('../routes/_uid_inject_db');
+const dbProxy = require('../routes/db_proxy');
+const dbProxyHandler = dbProxy.stack?.[0]?.handle;
+
+assert.strictEqual(typeof dbProxyHandler, 'function', 'db_proxy handler not found');
+
+function makeLegacyToken(uid) {
+  return `t_${Buffer.from(JSON.stringify({ uid })).toString('base64url')}`;
+}
+
+function makeReq(query, userId) {
+  const rawQuery = new URLSearchParams(query).toString();
+  const req = {
+    path: '/activity_detail',
+    originalUrl: `/gw/api/db/activity_detail${rawQuery ? `?${rawQuery}` : ''}`,
+    method: 'GET',
+    query: { ...query },
+    headers: {},
+    get(name) {
+      return this.headers[String(name).toLowerCase()];
+    },
+  };
+
+  if (userId) {
+    req.headers.authorization = `Bearer ${makeLegacyToken(userId)}`;
+  }
+
+  return req;
+}
+
+function makeRes() {
+  let resolveDone;
+  const done = new Promise((resolve) => {
+    resolveDone = resolve;
+  });
+
+  const res = {
+    statusCode: 200,
+    headers: {},
+    locals: {},
+    body: undefined,
+    finished: false,
+    done,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    set(name, value) {
+      if (typeof name === 'object') {
+        for (const [key, item] of Object.entries(name)) this.headers[key.toLowerCase()] = item;
+        return this;
+      }
+      this.headers[String(name).toLowerCase()] = value;
+      return this;
+    },
+    send(body) {
+      this.body = body;
+      this.finished = true;
+      resolveDone(this);
+      return this;
+    },
+    json(body) {
+      this.jsonBody = body;
+      this.set('content-type', 'application/json; charset=utf-8');
+      return this.send(JSON.stringify(body));
+    },
+  };
+
+  return res;
+}
+
+async function runUidInject(req, res) {
+  let nextCalled = false;
+
+  await new Promise((resolve, reject) => {
+    const next = (error) => {
+      if (error) return reject(error);
+      nextCalled = true;
+      return resolve();
+    };
+
+    try {
+      const returned = uidInjectDb(req, res, next);
+      if (returned && typeof returned.then === 'function') returned.then(resolve, reject);
+    } catch (error) {
+      reject(error);
+    }
+
+    res.done.then(resolve);
+  });
+
+  return nextCalled;
+}
+
+async function runDbProxy(req, res) {
+  await new Promise((resolve, reject) => {
+    const next = (error) => (error ? reject(error) : resolve());
+
+    try {
+      const returned = dbProxyHandler(req, res, next);
+      if (returned && typeof returned.then === 'function') returned.then(resolve, reject);
+    } catch (error) {
+      reject(error);
+    }
+
+    res.done.then(resolve);
+  });
+}
+
+async function runRequest(query, userId) {
+  const req = makeReq(query, userId);
+  const res = makeRes();
+  if (await runUidInject(req, res)) await runDbProxy(req, res);
+  return res;
+}
+
+async function main() {
+  try {
+    let response = await runRequest({ training_id: 'train-123' }, 'user-42');
+    assert.strictEqual(response.statusCode, 200);
+    const payload = JSON.parse(response.body);
+    assert.strictEqual(payload.ok, true);
+
+    assert.strictEqual(upstreamHits.length, 1);
+    let hit = upstreamHits[0];
+    let forwarded = new URL(hit.url);
+    assert.strictEqual(hit.method, 'GET');
+    assert.strictEqual(forwarded.pathname, '/api/db/activity_detail');
+    assert.strictEqual(forwarded.searchParams.get('training_id'), 'train-123');
+    assert.strictEqual(forwarded.searchParams.get('user_id'), 'user-42');
+    assert.strictEqual(hit.headers['X-API-Key'], 'test-stas-key');
+
+    response = await runRequest({ training_id: 'train-456', user_id: 'explicit-7' }, 'user-42');
+    assert.strictEqual(response.statusCode, 200);
+
+    assert.strictEqual(upstreamHits.length, 2);
+    hit = upstreamHits[1];
+    forwarded = new URL(hit.url);
+    assert.strictEqual(forwarded.pathname, '/api/db/activity_detail');
+    assert.strictEqual(forwarded.searchParams.get('training_id'), 'train-456');
+    assert.strictEqual(forwarded.searchParams.get('user_id'), 'explicit-7');
+
+    response = await runRequest({ training_id: 'train-789' });
+    assert.strictEqual(response.statusCode, 401);
+    assert.deepStrictEqual(response.jsonBody, { status: 401, error: 'missing_or_invalid_token' });
+    assert.strictEqual(upstreamHits.length, 2);
+
+    console.log('ok - db_proxy forwards activity_detail and handles user_id/auth');
+  } finally {
+    global.fetch = originalFetch;
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Supersedes #5 with a clean branch based directly on origin/main.
- Documents the /gw/api/db/activity_detail gateway route in the full and minimized OpenAPI specs.
- Adds local smoke coverage for db_proxy activity_detail forwarding and auth/user_id handling.

## Why

PR #5 was based on a local main that was ahead of origin/main, so it included unrelated harness commits. This replacement keeps only the activity_detail gateway documentation and smoke coverage.

## Validation

- npm run test:db-proxy
- JSON.parse(openapi.actions.json)
- JSON.parse(openapi.min.json)
- git diff --check origin/main...HEAD
- git diff --check
