### PR TITLE
Publish canonical ChatGPT and MCP goals contract

### DIFF
--- a/openapi.actions.json
+++ b/openapi.actions.json
@@ -51,45 +51,6 @@
         }
       }
     },
-    "/gw/api/db/goals/current": {
-      "get": {
-        "operationId": "getCurrentGoalsStartsResults",
-        "summary": "Get current bounded goals, starts, and results",
-        "description": "Read the existing current-only P08 projection with stable public IDs. This action does not start sync, matching, reconciliation, confirmation, or any provider operation.",
-        "responses": {
-          "200": {
-            "description": "Current bounded goals, starts, and results projection",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AnalysisProjectionResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Missing, invalid, or unresolvable user token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Current compact goals projection is unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/gw/api/db/user_summary": {
       "get": {
         "operationId": "getUserSummary",
@@ -118,39 +79,11 @@
         }
       }
     },
-    "/gw/api/db/trainings": {
-      "get": {
-        "operationId": "getTrainingsFromDB",
-        "summary": "Get trainings from STAS DB",
-        "responses": {
-          "200": {
-            "description": "Trainings array",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TrainingsListResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Missing or invalid token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/gw/api/db/activity_detail": {
       "get": {
         "operationId": "getActivityDetailFromDB",
         "summary": "Get detailed package for one completed training",
-        "description": "Read-only detailed package for one selected completed workout. Use after getTrainingsFromDB or getFullTrainings identifies the exact training_id. Do not batch this action across many workouts. The response omits rawData, route coordinates, latlng, and raw stream arrays.",
+        "description": "Read-only detailed package for one selected completed workout. Use after getTrainings identifies the exact training_id. Do not batch this action across many workouts. The response omits rawData, route coordinates, latlng, and raw stream arrays.",
         "parameters": [
           {
             "name": "training_id",
@@ -196,6 +129,45 @@
           },
           "404": {
             "description": "Training not found for current user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/gw/api/db/goals/current": {
+      "get": {
+        "operationId": "getCurrentGoalsStartsResults",
+        "summary": "Get current bounded goals, starts, and results",
+        "description": "Read-only current state only. It does not sync, match, confirm, or change anything. The server returns the existing P08 AnalysisProjection without an envelope: at most 16 items and at most 12 KB UTF-8 at runtime.",
+        "responses": {
+          "200": {
+            "description": "Current bounded goals, starts, and results projection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnalysisProjectionResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Current goals projection is unavailable",
             "content": {
               "application/json": {
                 "schema": {
@@ -760,9 +732,9 @@
     },
     "/gw/trainings": {
       "get": {
-        "operationId": "getFullTrainings",
-        "summary": "Get trainings with optional intervals/signals",
-        "description": "Returns a bare array. full=true may include intervals, splits, and work signals where available; rawData, raw streams, and route coordinates are not included.",
+        "operationId": "getTrainings",
+        "summary": "Get a bounded completed-workout list from STAS",
+        "description": "One size-safe list with two modes. Default mode is a rich index for chronology, load, reports, compact interval/split summaries, and choosing training_id. Set full=true only for analysis-rich comparison across multiple workouts in a bounded date window; it adds a bounded compact interval projection. For one selected workout, call getActivityDetailFromDB instead of full=true. Read each item's listDetail accounting before deciding whether exact detail is needed.",
         "parameters": [
           {
             "name": "oldest",
@@ -823,14 +795,14 @@
             "required": false,
             "schema": {
               "type": "boolean",
-              "default": true
+              "default": false
             },
-            "description": "Include intervals, splits, and work signals where available; rawData, raw streams, and route are not included."
+            "description": "Optional analysis-rich list mode for comparing multiple workouts. It is still compact and size-safe, not raw data and not the detailed view for one workout. Omit it for listing/lookup; use getActivityDetailFromDB after selecting one exact training_id."
           }
         ],
         "responses": {
           "200": {
-            "description": "Trainings array",
+            "description": "Bounded completed-workout list with per-item listDetail accounting",
             "content": {
               "application/json": {
                 "schema": {
@@ -876,7 +848,7 @@
       "get": {
         "operationId": "getUserSummaryGw",
         "summary": "Get full user summary via gateway in up to two parts",
-        "description": "Call part 1. On partial, call part 2 with expectedVersion, merge top-level data, and only then answer. On version_mismatch restart. Use summaryFreshness: stale/refresh_failed means not verified current; null means unavailable, not zero. Max two calls per version.",
+        "description": "Call part 1. On partial, call part 2 with expectedVersion, merge the top-level data, and only then answer. On version_mismatch restart. Use summaryFreshness: stale or refresh_failed means not verified current; null means unavailable, not zero. Make at most two calls per summaryVersion.",
         "parameters": [
           {
             "name": "part",
@@ -1310,54 +1282,6 @@
       }
     },
     "schemas": {
-      "AnalysisProjectionResponse": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "version",
-          "dataVersion",
-          "asOfDate",
-          "items",
-          "bestResults",
-          "omittedCount",
-          "limitations"
-        ],
-        "properties": {
-          "version": {
-            "const": 1
-          },
-          "dataVersion": {
-            "type": "string",
-            "pattern": "^[a-f0-9]{64}$"
-          },
-          "asOfDate": {
-            "type": "string",
-            "format": "date"
-          },
-          "items": {
-            "type": "array",
-            "maxItems": 16,
-            "items": {
-              "type": "object",
-              "description": "Existing P08 current item with stable public IDs, bounded user text, lifecycle, result lanes and limitations."
-            }
-          },
-          "bestResults": {
-            "type": "object",
-            "description": "Existing P08 bounded current, accepted, derived and manual best-result lanes."
-          },
-          "omittedCount": {
-            "type": "integer",
-            "minimum": 0
-          },
-          "limitations": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        }
-      },
       "ErrorResponse": {
         "type": "object",
         "properties": {
@@ -1382,6 +1306,604 @@
             "additionalProperties": true
           }
         },
+        "additionalProperties": false
+      },
+      "AnalysisProjectionResponse": {
+        "type": "object",
+        "description": "Exact P08 current-state projection. The server enforces a 12 KB UTF-8 response budget.",
+        "properties": {
+          "version": {
+            "type": "integer",
+            "const": 1
+          },
+          "dataVersion": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          },
+          "asOfDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "items": {
+            "type": "array",
+            "maxItems": 16,
+            "items": {
+              "$ref": "#/components/schemas/AnalysisProjectionItem"
+            }
+          },
+          "bestResults": {
+            "$ref": "#/components/schemas/AnalysisProjectionBestResults"
+          },
+          "omittedCount": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "limitations": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "version",
+          "dataVersion",
+          "asOfDate",
+          "items",
+          "bestResults",
+          "omittedCount",
+          "limitations"
+        ],
+        "additionalProperties": false
+      },
+      "AnalysisProjectionItem": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "general",
+              "event"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "archived",
+              "unknown"
+            ]
+          },
+          "position": {
+            "type": "integer"
+          },
+          "label": {
+            "type": "string",
+            "description": "Server-truncated user text."
+          },
+          "target": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Server-truncated user text."
+          },
+          "date": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date"
+          },
+          "timezone": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sport": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "distanceMeters": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "priority": {
+            "type": "string",
+            "enum": [
+              "A",
+              "B",
+              "C",
+              "unknown"
+            ]
+          },
+          "lifecycle": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "upcoming",
+              "awaiting_result",
+              "completed",
+              "cancelled",
+              "dns",
+              "archived",
+              "unknown",
+              null
+            ]
+          },
+          "syncState": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "pending",
+              "synced",
+              "conflict",
+              "error",
+              "delete_pending",
+              "deleted",
+              "unknown",
+              null
+            ]
+          },
+          "raceResultId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid"
+          },
+          "resultStatus": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "pending",
+              "observed",
+              "confirmed",
+              "invalidated",
+              "unknown",
+              null
+            ]
+          },
+          "evidence": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "activeCount": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "invalidatedCount": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "roles": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "primary",
+                    "candidate",
+                    "supporting",
+                    "manual"
+                  ]
+                }
+              },
+              "levels": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "exact",
+                    "high_confidence",
+                    "provisional",
+                    "ambiguous",
+                    "unlinked",
+                    "invalidated",
+                    "unknown"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "activeCount",
+              "invalidatedCount",
+              "roles",
+              "levels"
+            ],
+            "additionalProperties": false
+          },
+          "results": {
+            "$ref": "#/components/schemas/AnalysisProjectionResults"
+          },
+          "limitations": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "kind",
+          "status",
+          "position",
+          "label",
+          "target",
+          "date",
+          "timezone",
+          "sport",
+          "distanceMeters",
+          "priority",
+          "lifecycle",
+          "syncState",
+          "raceResultId",
+          "resultStatus",
+          "evidence",
+          "results",
+          "limitations"
+        ],
+        "additionalProperties": false
+      },
+      "AnalysisProjectionResults": {
+        "type": "object",
+        "properties": {
+          "observedMoving": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AnalysisProjectionResultLane"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "observedElapsed": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AnalysisProjectionResultLane"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "officialChip": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AnalysisProjectionResultLane"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "officialGun": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AnalysisProjectionResultLane"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "manual": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AnalysisProjectionResultLane"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "observedMoving",
+          "observedElapsed",
+          "officialChip",
+          "officialGun",
+          "manual"
+        ],
+        "additionalProperties": false
+      },
+      "AnalysisProjectionResultLane": {
+        "type": "object",
+        "properties": {
+          "seconds": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "source": {
+            "type": "string",
+            "enum": [
+              "observed_moving",
+              "observed_elapsed",
+              "official_chip",
+              "official_gun",
+              "manual"
+            ]
+          },
+          "evidenceLevel": {
+            "type": "string",
+            "enum": [
+              "exact",
+              "high_confidence",
+              "provisional",
+              "ambiguous",
+              "unlinked",
+              "invalidated",
+              "unknown"
+            ]
+          },
+          "confidence": {
+            "type": "string",
+            "enum": [
+              "high",
+              "medium",
+              "low",
+              "unknown"
+            ]
+          },
+          "limitations": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "seconds",
+          "source",
+          "evidenceLevel",
+          "confidence",
+          "limitations"
+        ],
+        "additionalProperties": false
+      },
+      "AnalysisProjectionBestResults": {
+        "type": "object",
+        "properties": {
+          "current": {
+            "type": "array",
+            "maxItems": 16,
+            "items": {
+              "type": "object",
+              "properties": {
+                "semanticKey": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "distance": {
+                  "type": "string"
+                },
+                "seconds": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "date": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "format": "date"
+                },
+                "source": {
+                  "type": "string",
+                  "const": "user_claimed_legacy"
+                },
+                "resultKind": {
+                  "type": "string",
+                  "const": "legacy_unspecified"
+                },
+                "limitations": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "semanticKey",
+                "distance",
+                "seconds",
+                "date",
+                "source",
+                "resultKind",
+                "limitations"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "accepted": {
+            "type": "array",
+            "maxItems": 16,
+            "items": {
+              "type": "object",
+              "properties": {
+                "semanticKey": {
+                  "type": "string"
+                },
+                "resultKind": {
+                  "type": "string",
+                  "enum": [
+                    "observed_moving",
+                    "observed_elapsed",
+                    "official_chip",
+                    "official_gun",
+                    "manual"
+                  ]
+                },
+                "seconds": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              },
+              "required": [
+                "semanticKey",
+                "resultKind",
+                "seconds"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "derivedBestKnown": {
+            "type": "array",
+            "maxItems": 16,
+            "items": {
+              "type": "object",
+              "properties": {
+                "semanticKey": {
+                  "type": "string"
+                },
+                "raceResultId": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "format": "uuid"
+                },
+                "resultKind": {
+                  "type": "string",
+                  "enum": [
+                    "observed_moving",
+                    "observed_elapsed",
+                    "official_chip",
+                    "official_gun",
+                    "manual"
+                  ]
+                },
+                "seconds": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "date": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "format": "date"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "detected",
+                    "improvement",
+                    "not_improvement",
+                    "not_comparable"
+                  ]
+                },
+                "evidenceLevel": {
+                  "type": "string",
+                  "enum": [
+                    "exact",
+                    "high_confidence",
+                    "provisional",
+                    "ambiguous",
+                    "unlinked",
+                    "invalidated",
+                    "unknown"
+                  ]
+                },
+                "confidence": {
+                  "type": "string",
+                  "enum": [
+                    "high",
+                    "medium",
+                    "low",
+                    "unknown"
+                  ]
+                },
+                "limitations": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "semanticKey",
+                "raceResultId",
+                "resultKind",
+                "seconds",
+                "date",
+                "status",
+                "evidenceLevel",
+                "confidence",
+                "limitations"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "manual": {
+            "type": "array",
+            "maxItems": 16,
+            "items": {
+              "type": "object",
+              "properties": {
+                "sport": {
+                  "type": "string",
+                  "enum": [
+                    "run",
+                    "ride",
+                    "swim"
+                  ]
+                },
+                "distanceMeters": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "seconds": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "actualDate": {
+                  "type": "string",
+                  "format": "date"
+                }
+              },
+              "required": [
+                "sport",
+                "distanceMeters",
+                "seconds",
+                "actualDate"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "omittedCount": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "current",
+          "accepted",
+          "derivedBestKnown",
+          "manual",
+          "omittedCount"
+        ],
         "additionalProperties": false
       },
       "MeResponse": {
@@ -2417,6 +2939,10 @@
                 "type": "null"
               }
             ]
+          },
+          "listDetail": {
+            "$ref": "#/components/schemas/TrainingListDetail",
+            "description": "Exact accounting for the size-safe list projection. If a section is truncated and exact execution matters, call getActivityDetailFromDB for this training id."
           }
         },
         "required": [
@@ -2424,6 +2950,74 @@
           "date"
         ],
         "additionalProperties": true
+      },
+      "TrainingListDetail": {
+        "type": "object",
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "index",
+              "analysis"
+            ]
+          },
+          "detailAvailable": {
+            "type": "boolean"
+          },
+          "intervals": {
+            "$ref": "#/components/schemas/TrainingListSectionAccounting"
+          },
+          "intervalSummary": {
+            "$ref": "#/components/schemas/TrainingListSectionAccounting"
+          },
+          "splits": {
+            "$ref": "#/components/schemas/TrainingListSectionAccounting"
+          },
+          "userReportTruncated": {
+            "type": "boolean"
+          },
+          "responseBudgetAdjusted": {
+            "type": "boolean"
+          },
+          "fieldsOmittedForResponseBudget": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "mode",
+          "detailAvailable",
+          "intervals",
+          "intervalSummary",
+          "splits",
+          "userReportTruncated",
+          "responseBudgetAdjusted"
+        ],
+        "additionalProperties": true
+      },
+      "TrainingListSectionAccounting": {
+        "type": "object",
+        "properties": {
+          "available": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "returned": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "truncated": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "available",
+          "returned",
+          "truncated"
+        ],
+        "additionalProperties": false
       },
       "TrainingsListResponse": {
         "type": "array",

--- a/openapi.actions.json
+++ b/openapi.actions.json
@@ -140,50 +140,11 @@
         }
       }
     },
-    "/gw/api/db/goals/current": {
-      "get": {
-        "operationId": "getCurrentGoalsStartsResults",
-        "summary": "Get current bounded goals, starts, and results",
-        "description": "Read-only current state only. It does not sync, match, confirm, or change anything. The server returns the existing P08 AnalysisProjection without an envelope: at most 16 items and at most 12 KB UTF-8 at runtime.",
-        "responses": {
-          "200": {
-            "description": "Current bounded goals, starts, and results projection",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AnalysisProjectionResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Missing or invalid token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Current goals projection is unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/gw/api/db/profile_sections": {
       "get": {
         "operationId": "readProfileSections",
         "summary": "Read profile memory sections",
-        "description": "Read current profile, goals, and rules with hashes. Use before preview so the saved hash is fresh. This does not write anything.",
+        "description": "Read current rules and profile memory with hashes. Goals and results are available only through getEditableGoalsResults.",
         "responses": {
           "200": {
             "description": "Profile sections payload",
@@ -198,7 +159,7 @@
                     "sections": {
                       "type": "array",
                       "items": {
-                        "$ref": "#/components/schemas/ProfileSection"
+                        "$ref": "#/components/schemas/ActiveProfileSection"
                       }
                     }
                   },
@@ -228,7 +189,7 @@
       "post": {
         "operationId": "previewProfileSectionChange",
         "summary": "Preview a profile memory change",
-        "description": "Preview one rules/profile memory change. Goals, starts, calendar links, and results must use previewGoalResultChange. Never saves; commit only after exact confirmation.",
+        "description": "Preview one rules/profile memory change. Identical normalized text returns noChange=true and creates no history record. Goals and results use previewGoalResultChange.",
         "requestBody": {
           "required": true,
           "content": {
@@ -245,7 +206,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProfileWriteResult"
+                  "$ref": "#/components/schemas/ProfileSectionPreviewResult"
                 }
               }
             }
@@ -365,8 +326,8 @@
     "/gw/api/db/profile_changes": {
       "get": {
         "operationId": "readProfileChangeHistory",
-        "summary": "Read profile memory change history",
-        "description": "Read profile/goals/rules change history. This is read-only. Use before restore decisions, not as permission to restore.",
+        "summary": "Read compact profile change history",
+        "description": "Read a compact paginated history index. Full texts and hashes are omitted; use readProfileChangeDetail for one selected record.",
         "parameters": [
           {
             "name": "section",
@@ -379,8 +340,7 @@
                 "goals",
                 "rules"
               ]
-            },
-            "description": "Optional profile section filter."
+            }
           },
           {
             "name": "status",
@@ -396,8 +356,7 @@
                 "conflict",
                 "rejected"
               ]
-            },
-            "description": "Optional change status filter."
+            }
           },
           {
             "name": "limit",
@@ -406,34 +365,28 @@
             "schema": {
               "type": "integer",
               "minimum": 1,
-              "maximum": 100
+              "maximum": 20,
+              "default": 10
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
             },
-            "description": "Maximum number of changes to return."
+            "description": "nextCursor from the previous page."
           }
         ],
         "responses": {
           "200": {
-            "description": "Profile change history",
+            "description": "Compact profile change history",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean"
-                    },
-                    "changes": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/ProfileMemoryChange"
-                      }
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "changes"
-                  ],
-                  "additionalProperties": false
+                  "$ref": "#/components/schemas/ProfileMemoryHistoryPage"
                 }
               }
             }
@@ -455,7 +408,7 @@
       "post": {
         "operationId": "restoreProfileChange",
         "summary": "Restore a profile memory change",
-        "description": "Restore a committed profile/goals/rules change. Call only after showing exact restore text and getting explicit user confirmation.",
+        "description": "Restore one committed change only after readProfileChangeDetail and explicit confirmation of the exact previous text.",
         "parameters": [
           {
             "name": "changeId",
@@ -1259,6 +1212,56 @@
           }
         }
       }
+    },
+    "/gw/api/db/profile_changes/{changeId}": {
+      "get": {
+        "operationId": "readProfileChangeDetail",
+        "summary": "Read one profile change in full",
+        "description": "Load exact old/new text and hashes for one record selected from readProfileChangeHistory. This is read-only.",
+        "parameters": [
+          {
+            "name": "changeId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Full profile change record",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileMemoryChangeDetailResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Profile change not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -1306,259 +1309,6 @@
             "additionalProperties": true
           }
         },
-        "additionalProperties": false
-      },
-      "AnalysisProjectionResponse": {
-        "type": "object",
-        "description": "Exact P08 current-state projection. The server enforces a 12 KB UTF-8 response budget.",
-        "properties": {
-          "version": {
-            "type": "integer",
-            "const": 1
-          },
-          "dataVersion": {
-            "type": "string",
-            "pattern": "^[0-9a-f]{64}$"
-          },
-          "asOfDate": {
-            "type": "string",
-            "format": "date"
-          },
-          "items": {
-            "type": "array",
-            "maxItems": 16,
-            "items": {
-              "$ref": "#/components/schemas/AnalysisProjectionItem"
-            }
-          },
-          "bestResults": {
-            "$ref": "#/components/schemas/AnalysisProjectionBestResults"
-          },
-          "omittedCount": {
-            "type": "integer",
-            "minimum": 0
-          },
-          "limitations": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "required": [
-          "version",
-          "dataVersion",
-          "asOfDate",
-          "items",
-          "bestResults",
-          "omittedCount",
-          "limitations"
-        ],
-        "additionalProperties": false
-      },
-      "AnalysisProjectionItem": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "kind": {
-            "type": "string",
-            "enum": [
-              "general",
-              "event"
-            ]
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "active",
-              "archived",
-              "unknown"
-            ]
-          },
-          "position": {
-            "type": "integer"
-          },
-          "label": {
-            "type": "string",
-            "description": "Server-truncated user text."
-          },
-          "target": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Server-truncated user text."
-          },
-          "date": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "format": "date"
-          },
-          "timezone": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "sport": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "distanceMeters": {
-            "type": [
-              "integer",
-              "null"
-            ]
-          },
-          "priority": {
-            "type": "string",
-            "enum": [
-              "A",
-              "B",
-              "C",
-              "unknown"
-            ]
-          },
-          "lifecycle": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "enum": [
-              "upcoming",
-              "awaiting_result",
-              "completed",
-              "cancelled",
-              "dns",
-              "archived",
-              "unknown",
-              null
-            ]
-          },
-          "syncState": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "enum": [
-              "pending",
-              "synced",
-              "conflict",
-              "error",
-              "delete_pending",
-              "deleted",
-              "unknown",
-              null
-            ]
-          },
-          "raceResultId": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "format": "uuid"
-          },
-          "resultStatus": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "enum": [
-              "pending",
-              "observed",
-              "confirmed",
-              "invalidated",
-              "unknown",
-              null
-            ]
-          },
-          "evidence": {
-            "type": [
-              "object",
-              "null"
-            ],
-            "properties": {
-              "activeCount": {
-                "type": "integer",
-                "minimum": 0
-              },
-              "invalidatedCount": {
-                "type": "integer",
-                "minimum": 0
-              },
-              "roles": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "enum": [
-                    "primary",
-                    "candidate",
-                    "supporting",
-                    "manual"
-                  ]
-                }
-              },
-              "levels": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "enum": [
-                    "exact",
-                    "high_confidence",
-                    "provisional",
-                    "ambiguous",
-                    "unlinked",
-                    "invalidated",
-                    "unknown"
-                  ]
-                }
-              }
-            },
-            "required": [
-              "activeCount",
-              "invalidatedCount",
-              "roles",
-              "levels"
-            ],
-            "additionalProperties": false
-          },
-          "results": {
-            "$ref": "#/components/schemas/AnalysisProjectionResults"
-          },
-          "limitations": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "required": [
-          "id",
-          "kind",
-          "status",
-          "position",
-          "label",
-          "target",
-          "date",
-          "timezone",
-          "sport",
-          "distanceMeters",
-          "priority",
-          "lifecycle",
-          "syncState",
-          "raceResultId",
-          "resultStatus",
-          "evidence",
-          "results",
-          "limitations"
-        ],
         "additionalProperties": false
       },
       "AnalysisProjectionResults": {
@@ -1675,234 +1425,6 @@
           "evidenceLevel",
           "confidence",
           "limitations"
-        ],
-        "additionalProperties": false
-      },
-      "AnalysisProjectionBestResults": {
-        "type": "object",
-        "properties": {
-          "current": {
-            "type": "array",
-            "maxItems": 16,
-            "items": {
-              "type": "object",
-              "properties": {
-                "semanticKey": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "distance": {
-                  "type": "string"
-                },
-                "seconds": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "date": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "format": "date"
-                },
-                "source": {
-                  "type": "string",
-                  "const": "user_claimed_legacy"
-                },
-                "resultKind": {
-                  "type": "string",
-                  "const": "legacy_unspecified"
-                },
-                "limitations": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              },
-              "required": [
-                "semanticKey",
-                "distance",
-                "seconds",
-                "date",
-                "source",
-                "resultKind",
-                "limitations"
-              ],
-              "additionalProperties": false
-            }
-          },
-          "accepted": {
-            "type": "array",
-            "maxItems": 16,
-            "items": {
-              "type": "object",
-              "properties": {
-                "semanticKey": {
-                  "type": "string"
-                },
-                "resultKind": {
-                  "type": "string",
-                  "enum": [
-                    "observed_moving",
-                    "observed_elapsed",
-                    "official_chip",
-                    "official_gun",
-                    "manual"
-                  ]
-                },
-                "seconds": {
-                  "type": "integer",
-                  "minimum": 1
-                }
-              },
-              "required": [
-                "semanticKey",
-                "resultKind",
-                "seconds"
-              ],
-              "additionalProperties": false
-            }
-          },
-          "derivedBestKnown": {
-            "type": "array",
-            "maxItems": 16,
-            "items": {
-              "type": "object",
-              "properties": {
-                "semanticKey": {
-                  "type": "string"
-                },
-                "raceResultId": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "format": "uuid"
-                },
-                "resultKind": {
-                  "type": "string",
-                  "enum": [
-                    "observed_moving",
-                    "observed_elapsed",
-                    "official_chip",
-                    "official_gun",
-                    "manual"
-                  ]
-                },
-                "seconds": {
-                  "type": "integer",
-                  "minimum": 1
-                },
-                "date": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "format": "date"
-                },
-                "status": {
-                  "type": "string",
-                  "enum": [
-                    "detected",
-                    "improvement",
-                    "not_improvement",
-                    "not_comparable"
-                  ]
-                },
-                "evidenceLevel": {
-                  "type": "string",
-                  "enum": [
-                    "exact",
-                    "high_confidence",
-                    "provisional",
-                    "ambiguous",
-                    "unlinked",
-                    "invalidated",
-                    "unknown"
-                  ]
-                },
-                "confidence": {
-                  "type": "string",
-                  "enum": [
-                    "high",
-                    "medium",
-                    "low",
-                    "unknown"
-                  ]
-                },
-                "limitations": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              },
-              "required": [
-                "semanticKey",
-                "raceResultId",
-                "resultKind",
-                "seconds",
-                "date",
-                "status",
-                "evidenceLevel",
-                "confidence",
-                "limitations"
-              ],
-              "additionalProperties": false
-            }
-          },
-          "manual": {
-            "type": "array",
-            "maxItems": 16,
-            "items": {
-              "type": "object",
-              "properties": {
-                "sport": {
-                  "type": "string",
-                  "enum": [
-                    "run",
-                    "ride",
-                    "swim"
-                  ]
-                },
-                "distanceMeters": {
-                  "type": "integer",
-                  "minimum": 1
-                },
-                "seconds": {
-                  "type": "integer",
-                  "minimum": 1
-                },
-                "actualDate": {
-                  "type": "string",
-                  "format": "date"
-                }
-              },
-              "required": [
-                "sport",
-                "distanceMeters",
-                "seconds",
-                "actualDate"
-              ],
-              "additionalProperties": false
-            }
-          },
-          "omittedCount": {
-            "type": "integer",
-            "minimum": 0
-          }
-        },
-        "required": [
-          "current",
-          "accepted",
-          "derivedBestKnown",
-          "manual",
-          "omittedCount"
         ],
         "additionalProperties": false
       },
@@ -2350,46 +1872,6 @@
             "description": "Additional durable profile context. Do not use for firstName."
           }
         }
-      },
-      "ProfileMemoryStructuredGoals": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "items": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "date": {
-                  "type": "string",
-                  "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
-                  "description": "Optional exact goal date in YYYY-MM-DD. Omit when unknown; approximate dates are not supported."
-                },
-                "goal": {
-                  "type": "string",
-                  "description": "Required goal or event, for example 5 км, 10 км, regularity, health, cycling event, or triathlon."
-                },
-                "targetResult": {
-                  "type": "string",
-                  "description": "Target result or measurable outcome. Omit when unknown; server writes `не указано`."
-                },
-                "comment": {
-                  "type": "string",
-                  "description": "Short durable context: role, preparation depth, taper/risk note, or season meaning. Omit when unknown; server writes `не указано`."
-                }
-              },
-              "required": [
-                "goal"
-              ]
-            },
-            "description": "Flat goals list in the same shape as the web profile card. Every dated race is a real goal by default; do not demote goals into lower-value categories.",
-            "minItems": 1
-          }
-        },
-        "required": [
-          "items"
-        ]
       },
       "ProfileMemoryStructuredRules": {
         "type": "object",
@@ -4072,13 +3554,22 @@
         "additionalProperties": true
       },
       "GoalResultEditCommand": {
+        "description": "One canonical command. Choose command.type only from the listed oneOf variants; aliases such as create, update, delete, add_goal, or update_goal are invalid.",
+        "discriminator": {
+          "propertyName": "type"
+        },
         "oneOf": [
           {
             "type": "object",
             "additionalProperties": false,
+            "description": "Canonical general_create command. Send this exact command.type and no alias.",
             "properties": {
               "type": {
-                "const": "general_create"
+                "type": "string",
+                "enum": [
+                  "general_create"
+                ],
+                "description": "Use exactly \"general_create\" as command.type."
               },
               "operationId": {
                 "type": "string",
@@ -4149,9 +3640,14 @@
           {
             "type": "object",
             "additionalProperties": false,
+            "description": "Canonical general_update command. Send this exact command.type and no alias.",
             "properties": {
               "type": {
-                "const": "general_update"
+                "type": "string",
+                "enum": [
+                  "general_update"
+                ],
+                "description": "Use exactly \"general_update\" as command.type."
               },
               "operationId": {
                 "type": "string",
@@ -4226,9 +3722,14 @@
           {
             "type": "object",
             "additionalProperties": false,
+            "description": "Canonical general_archive command. Send this exact command.type and no alias.",
             "properties": {
               "type": {
-                "const": "general_archive"
+                "type": "string",
+                "enum": [
+                  "general_archive"
+                ],
+                "description": "Use exactly \"general_archive\" as command.type."
               },
               "operationId": {
                 "type": "string",
@@ -4248,9 +3749,14 @@
           {
             "type": "object",
             "additionalProperties": false,
+            "description": "Canonical start_create command. Send this exact command.type and no alias.",
             "properties": {
               "type": {
-                "const": "start_create"
+                "type": "string",
+                "enum": [
+                  "start_create"
+                ],
+                "description": "Use exactly \"start_create\" as command.type."
               },
               "operationId": {
                 "type": "string",
@@ -4329,9 +3835,14 @@
           {
             "type": "object",
             "additionalProperties": false,
+            "description": "Canonical start_update command. Send this exact command.type and no alias.",
             "properties": {
               "type": {
-                "const": "start_update"
+                "type": "string",
+                "enum": [
+                  "start_update"
+                ],
+                "description": "Use exactly \"start_update\" as command.type."
               },
               "operationId": {
                 "type": "string",
@@ -4417,9 +3928,14 @@
           {
             "type": "object",
             "additionalProperties": false,
+            "description": "Canonical start_delete command. Send this exact command.type and no alias.",
             "properties": {
               "type": {
-                "const": "start_delete"
+                "type": "string",
+                "enum": [
+                  "start_delete"
+                ],
+                "description": "Use exactly \"start_delete\" as command.type."
               },
               "operationId": {
                 "type": "string",
@@ -4439,9 +3955,14 @@
           {
             "type": "object",
             "additionalProperties": false,
+            "description": "Canonical start_cancel command. Send this exact command.type and no alias.",
             "properties": {
               "type": {
-                "const": "start_cancel"
+                "type": "string",
+                "enum": [
+                  "start_cancel"
+                ],
+                "description": "Use exactly \"start_cancel\" as command.type."
               },
               "operationId": {
                 "type": "string",
@@ -4461,9 +3982,14 @@
           {
             "type": "object",
             "additionalProperties": false,
+            "description": "Canonical start_dns command. Send this exact command.type and no alias.",
             "properties": {
               "type": {
-                "const": "start_dns"
+                "type": "string",
+                "enum": [
+                  "start_dns"
+                ],
+                "description": "Use exactly \"start_dns\" as command.type."
               },
               "operationId": {
                 "type": "string",
@@ -4483,9 +4009,14 @@
           {
             "type": "object",
             "additionalProperties": false,
+            "description": "Canonical result_set command. Send this exact command.type and no alias.",
             "properties": {
               "type": {
-                "const": "result_set"
+                "type": "string",
+                "enum": [
+                  "result_set"
+                ],
+                "description": "Use exactly \"result_set\" as command.type."
               },
               "operationId": {
                 "type": "string",
@@ -4524,9 +4055,14 @@
           {
             "type": "object",
             "additionalProperties": false,
+            "description": "Canonical result_link_activity command. Send this exact command.type and no alias.",
             "properties": {
               "type": {
-                "const": "result_link_activity"
+                "type": "string",
+                "enum": [
+                  "result_link_activity"
+                ],
+                "description": "Use exactly \"result_link_activity\" as command.type."
               },
               "operationId": {
                 "type": "string",
@@ -4551,9 +4087,14 @@
           {
             "type": "object",
             "additionalProperties": false,
+            "description": "Canonical result_detach_activity command. Send this exact command.type and no alias.",
             "properties": {
               "type": {
-                "const": "result_detach_activity"
+                "type": "string",
+                "enum": [
+                  "result_detach_activity"
+                ],
+                "description": "Use exactly \"result_detach_activity\" as command.type."
               },
               "operationId": {
                 "type": "string",
@@ -4573,9 +4114,14 @@
           {
             "type": "object",
             "additionalProperties": false,
+            "description": "Canonical manual_result_create command. Send this exact command.type and no alias.",
             "properties": {
               "type": {
-                "const": "manual_result_create"
+                "type": "string",
+                "enum": [
+                  "manual_result_create"
+                ],
+                "description": "Use exactly \"manual_result_create\" as command.type."
               },
               "operationId": {
                 "type": "string",
@@ -4616,9 +4162,14 @@
           {
             "type": "object",
             "additionalProperties": false,
+            "description": "Canonical manual_result_update command. Send this exact command.type and no alias.",
             "properties": {
               "type": {
-                "const": "manual_result_update"
+                "type": "string",
+                "enum": [
+                  "manual_result_update"
+                ],
+                "description": "Use exactly \"manual_result_update\" as command.type."
               },
               "operationId": {
                 "type": "string",
@@ -4664,9 +4215,14 @@
           {
             "type": "object",
             "additionalProperties": false,
+            "description": "Canonical manual_result_delete command. Send this exact command.type and no alias.",
             "properties": {
               "type": {
-                "const": "manual_result_delete"
+                "type": "string",
+                "enum": [
+                  "manual_result_delete"
+                ],
+                "description": "Use exactly \"manual_result_delete\" as command.type."
               },
               "operationId": {
                 "type": "string",
@@ -4686,9 +4242,14 @@
           {
             "type": "object",
             "additionalProperties": false,
+            "description": "Canonical legacy_result_convert command. Send this exact command.type and no alias.",
             "properties": {
               "type": {
-                "const": "legacy_result_convert"
+                "type": "string",
+                "enum": [
+                  "legacy_result_convert"
+                ],
+                "description": "Use exactly \"legacy_result_convert\" as command.type."
               },
               "operationId": {
                 "type": "string",
@@ -4739,9 +4300,14 @@
           {
             "type": "object",
             "additionalProperties": false,
+            "description": "Canonical legacy_result_delete command. Send this exact command.type and no alias.",
             "properties": {
               "type": {
-                "const": "legacy_result_delete"
+                "type": "string",
+                "enum": [
+                  "legacy_result_delete"
+                ],
+                "description": "Use exactly \"legacy_result_delete\" as command.type."
               },
               "operationId": {
                 "type": "string",
@@ -5285,6 +4851,193 @@
             "$ref": "#/components/schemas/ProfileMemoryStructuredProfile"
           }
         }
+      },
+      "ActiveProfileSection": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "section": {
+            "type": "string",
+            "enum": [
+              "profile",
+              "rules"
+            ]
+          },
+          "targetField": {
+            "type": "string",
+            "enum": [
+              "info",
+              "rules"
+            ]
+          },
+          "text": {
+            "type": "string"
+          },
+          "hash": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "section",
+          "targetField",
+          "text",
+          "hash",
+          "enabled"
+        ]
+      },
+      "ProfileMemoryChangeSummary": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "section": {
+            "type": "string",
+            "enum": [
+              "profile",
+              "goals",
+              "rules"
+            ]
+          },
+          "targetField": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string",
+            "enum": [
+              "gpt",
+              "claude"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "previewed",
+              "committed",
+              "restored",
+              "expired",
+              "conflict",
+              "rejected"
+            ]
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 240
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "committedAt": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "section",
+          "targetField",
+          "source",
+          "status",
+          "summary",
+          "createdAt",
+          "committedAt",
+          "expiresAt"
+        ]
+      },
+      "ProfileMemoryHistoryPage": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "changes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProfileMemoryChangeSummary"
+            }
+          },
+          "nextCursor": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "changes",
+          "nextCursor"
+        ]
+      },
+      "ProfileMemoryChangeDetailResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "change": {
+            "$ref": "#/components/schemas/ProfileMemoryChange"
+          }
+        },
+        "required": [
+          "change"
+        ]
+      },
+      "ProfileSectionPreviewResult": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "ok": {
+            "const": true
+          },
+          "noChange": {
+            "type": "boolean",
+            "description": "When true, no history record exists and there is nothing to commit."
+          },
+          "change": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ProfileMemoryChange"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "section": {
+            "$ref": "#/components/schemas/ActiveProfileSection"
+          }
+        },
+        "required": [
+          "ok",
+          "noChange",
+          "change",
+          "section"
+        ]
       }
     }
   }

--- a/openapi.actions.json
+++ b/openapi.actions.json
@@ -734,7 +734,7 @@
       "get": {
         "operationId": "getTrainings",
         "summary": "Get a bounded completed-workout list from STAS",
-        "description": "One size-safe list with two modes. Default mode is a rich index for chronology, load, reports, compact interval/split summaries, and choosing training_id. Set full=true only for analysis-rich comparison across multiple workouts in a bounded date window; it adds a bounded compact interval projection. For one selected workout, call getActivityDetailFromDB instead of full=true. Read each item's listDetail accounting before deciding whether exact detail is needed.",
+        "description": "Size-safe workout list. Omit full for chronology, load, reports, and choosing training_id. Use full=true only to compare multiple workouts in a bounded date range. For one workout, call getActivityDetailFromDB. Check listDetail for omitted or truncated sections.",
         "parameters": [
           {
             "name": "oldest",

--- a/openapi.actions.json
+++ b/openapi.actions.json
@@ -51,6 +51,45 @@
         }
       }
     },
+    "/gw/api/db/goals/current": {
+      "get": {
+        "operationId": "getCurrentGoalsStartsResults",
+        "summary": "Get current bounded goals, starts, and results",
+        "description": "Read the existing current-only P08 projection with stable public IDs. This action does not start sync, matching, reconciliation, confirmation, or any provider operation.",
+        "responses": {
+          "200": {
+            "description": "Current bounded goals, starts, and results projection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnalysisProjectionResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing, invalid, or unresolvable user token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Current compact goals projection is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/gw/api/db/user_summary": {
       "get": {
         "operationId": "getUserSummary",
@@ -168,45 +207,6 @@
         }
       }
     },
-    "/gw/api/db/goals/current": {
-      "get": {
-        "operationId": "getCurrentGoalsStartsResults",
-        "summary": "Get current bounded goals, starts, and results",
-        "description": "Read-only current state only. It does not sync, match, confirm, or change anything. The server returns the existing P08 AnalysisProjection without an envelope: at most 16 items and at most 12 KB UTF-8 at runtime.",
-        "responses": {
-          "200": {
-            "description": "Current bounded goals, starts, and results projection",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AnalysisProjectionResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Missing or invalid token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Current goals projection is unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/gw/api/db/profile_sections": {
       "get": {
         "operationId": "readProfileSections",
@@ -256,7 +256,7 @@
       "post": {
         "operationId": "previewProfileSectionChange",
         "summary": "Preview a profile memory change",
-        "description": "Preview one profile/goals/rules section using structured fields. For goals, send a flat items list with optional exact ISO date, goal, target result, and comment; server builds canonical goals text. Never saves; commit only after exact confirmation.",
+        "description": "Preview one rules/profile memory change. Goals, starts, calendar links, and results must use previewGoalResultChange. Never saves; commit only after exact confirmation.",
         "requestBody": {
           "required": true,
           "content": {
@@ -325,7 +325,7 @@
       "post": {
         "operationId": "commitProfileSectionChange",
         "summary": "Commit a profile memory change",
-        "description": "Save a previewed profile/goals/rules change. Call only after the user confirms the exact full new text shown from preview.",
+        "description": "Save a previewed rules/profile change. Goals and results use commitGoalResultChange.",
         "requestBody": {
           "required": true,
           "content": {
@@ -876,7 +876,7 @@
       "get": {
         "operationId": "getUserSummaryGw",
         "summary": "Get full user summary via gateway in up to two parts",
-        "description": "Call part 1. On partial, call part 2 with expectedVersion, merge the top-level data, and only then answer. On version_mismatch restart. Use summaryFreshness: stale or refresh_failed means not verified current; null means unavailable, not zero. Make at most two calls per summaryVersion.",
+        "description": "Call part 1. On partial, call part 2 with expectedVersion, merge top-level data, and only then answer. On version_mismatch restart. Use summaryFreshness: stale/refresh_failed means not verified current; null means unavailable, not zero. Max two calls per version.",
         "parameters": [
           {
             "name": "part",
@@ -913,22 +913,22 @@
               }
             }
           },
-          "401": {
-            "description": "Missing or invalid token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Invalid request",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/UserSummaryV2InvalidRequestResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1003,6 +1003,290 @@
           }
         }
       }
+    },
+    "/gw/api/db/goals/editable": {
+      "get": {
+        "operationId": "getEditableGoalsResults",
+        "summary": "Read editable goals, starts, and results",
+        "description": "Read the authoritative current state before any goals/results change. Keep dataVersion and use it in previewGoalResultChange. This does not write anything.",
+        "responses": {
+          "200": {
+            "description": "Editable goals/results state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EditableGoalsResultsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Goals are unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/gw/api/db/goals/activity-candidates": {
+      "get": {
+        "operationId": "getGoalActivityCandidates",
+        "summary": "Read eligible activities for one start",
+        "description": "Read exact activity candidates before linking a completed start to an activity. Use only an event goal public ID from getEditableGoalsResults.",
+        "parameters": [
+          {
+            "name": "goal_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Event goal public ID."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Activity candidates",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GoalActivityCandidatesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid goal ID",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Goal not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/gw/api/db/goals/changes/preview": {
+      "post": {
+        "operationId": "previewGoalResultChange",
+        "summary": "Preview one exact goals or results change",
+        "description": "Required write gate: first read getEditableGoalsResults, then preview one exact change with that dataVersion. Show the returned before/after/effects and request explicit confirmation. This does not save anything.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "expectedDataVersion": {
+                    "type": "string",
+                    "pattern": "^[0-9a-f]{64}$",
+                    "description": "Exact dataVersion from getEditableGoalsResults."
+                  },
+                  "command": {
+                    "$ref": "#/components/schemas/GoalResultEditCommand"
+                  }
+                },
+                "required": [
+                  "expectedDataVersion",
+                  "command"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Change preview",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GoalResultChangePreviewResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid change",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Goal changes disabled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Target not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "State changed since read",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/gw/api/db/goals/changes/commit": {
+      "post": {
+        "operationId": "commitGoalResultChange",
+        "summary": "Commit a confirmed goals or results change",
+        "description": "Commit only the exact preview after the user explicitly confirms its before/after/effects. Then use returned state as the source of truth; calendar synchronization may still be pending.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "changeId": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Preview ID returned by previewGoalResultChange."
+                  }
+                },
+                "required": [
+                  "changeId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Committed change and authoritative state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GoalResultChangeCommitResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or expired preview",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Goal changes disabled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Preview not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "State changed since preview",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -1026,6 +1310,54 @@
       }
     },
     "schemas": {
+      "AnalysisProjectionResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "version",
+          "dataVersion",
+          "asOfDate",
+          "items",
+          "bestResults",
+          "omittedCount",
+          "limitations"
+        ],
+        "properties": {
+          "version": {
+            "const": 1
+          },
+          "dataVersion": {
+            "type": "string",
+            "pattern": "^[a-f0-9]{64}$"
+          },
+          "asOfDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "items": {
+            "type": "array",
+            "maxItems": 16,
+            "items": {
+              "type": "object",
+              "description": "Existing P08 current item with stable public IDs, bounded user text, lifecycle, result lanes and limitations."
+            }
+          },
+          "bestResults": {
+            "type": "object",
+            "description": "Existing P08 bounded current, accepted, derived and manual best-result lanes."
+          },
+          "omittedCount": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "limitations": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "ErrorResponse": {
         "type": "object",
         "properties": {
@@ -1050,82 +1382,6 @@
             "additionalProperties": true
           }
         },
-        "additionalProperties": false
-      },
-      "AnalysisProjectionResponse": {
-        "type": "object",
-        "description": "Exact P08 current-state projection. The server enforces a 12 KB UTF-8 response budget.",
-        "properties": {
-          "version": { "type": "integer", "const": 1 },
-          "dataVersion": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
-          "asOfDate": { "type": "string", "format": "date" },
-          "items": { "type": "array", "maxItems": 16, "items": { "$ref": "#/components/schemas/AnalysisProjectionItem" } },
-          "bestResults": { "$ref": "#/components/schemas/AnalysisProjectionBestResults" },
-          "omittedCount": { "type": "integer", "minimum": 0 },
-          "limitations": { "type": "array", "items": { "type": "string" } }
-        },
-        "required": ["version", "dataVersion", "asOfDate", "items", "bestResults", "omittedCount", "limitations"],
-        "additionalProperties": false
-      },
-      "AnalysisProjectionItem": {
-        "type": "object",
-        "properties": {
-          "id": { "type": "string", "format": "uuid" },
-          "kind": { "type": "string", "enum": ["general", "event"] },
-          "status": { "type": "string", "enum": ["active", "archived", "unknown"] },
-          "position": { "type": "integer" },
-          "label": { "type": "string", "description": "Server-truncated user text." },
-          "target": { "type": ["string", "null"], "description": "Server-truncated user text." },
-          "date": { "type": ["string", "null"], "format": "date" },
-          "timezone": { "type": ["string", "null"] },
-          "sport": { "type": ["string", "null"] },
-          "distanceMeters": { "type": ["integer", "null"] },
-          "priority": { "type": "string", "enum": ["A", "B", "C", "unknown"] },
-          "lifecycle": { "type": ["string", "null"], "enum": ["upcoming", "awaiting_result", "completed", "cancelled", "dns", "archived", "unknown", null] },
-          "syncState": { "type": ["string", "null"], "enum": ["pending", "synced", "conflict", "error", "delete_pending", "deleted", "unknown", null] },
-          "raceResultId": { "type": ["string", "null"], "format": "uuid" },
-          "resultStatus": { "type": ["string", "null"], "enum": ["pending", "observed", "confirmed", "invalidated", "unknown", null] },
-          "evidence": { "type": ["object", "null"], "properties": { "activeCount": { "type": "integer", "minimum": 0 }, "invalidatedCount": { "type": "integer", "minimum": 0 }, "roles": { "type": "array", "items": { "type": "string", "enum": ["primary", "candidate", "supporting", "manual"] } }, "levels": { "type": "array", "items": { "type": "string", "enum": ["exact", "high_confidence", "provisional", "ambiguous", "unlinked", "invalidated", "unknown"] } } }, "required": ["activeCount", "invalidatedCount", "roles", "levels"], "additionalProperties": false },
-          "results": { "$ref": "#/components/schemas/AnalysisProjectionResults" },
-          "limitations": { "type": "array", "items": { "type": "string" } }
-        },
-        "required": ["id", "kind", "status", "position", "label", "target", "date", "timezone", "sport", "distanceMeters", "priority", "lifecycle", "syncState", "raceResultId", "resultStatus", "evidence", "results", "limitations"],
-        "additionalProperties": false
-      },
-      "AnalysisProjectionResults": {
-        "type": "object",
-        "properties": {
-          "observedMoving": { "anyOf": [{ "$ref": "#/components/schemas/AnalysisProjectionResultLane" }, { "type": "null" }] },
-          "observedElapsed": { "anyOf": [{ "$ref": "#/components/schemas/AnalysisProjectionResultLane" }, { "type": "null" }] },
-          "officialChip": { "anyOf": [{ "$ref": "#/components/schemas/AnalysisProjectionResultLane" }, { "type": "null" }] },
-          "officialGun": { "anyOf": [{ "$ref": "#/components/schemas/AnalysisProjectionResultLane" }, { "type": "null" }] },
-          "manual": { "anyOf": [{ "$ref": "#/components/schemas/AnalysisProjectionResultLane" }, { "type": "null" }] }
-        },
-        "required": ["observedMoving", "observedElapsed", "officialChip", "officialGun", "manual"],
-        "additionalProperties": false
-      },
-      "AnalysisProjectionResultLane": {
-        "type": "object",
-        "properties": {
-          "seconds": { "type": "integer", "minimum": 1 },
-          "source": { "type": "string", "enum": ["observed_moving", "observed_elapsed", "official_chip", "official_gun", "manual"] },
-          "evidenceLevel": { "type": "string", "enum": ["exact", "high_confidence", "provisional", "ambiguous", "unlinked", "invalidated", "unknown"] },
-          "confidence": { "type": "string", "enum": ["high", "medium", "low", "unknown"] },
-          "limitations": { "type": "array", "items": { "type": "string" } }
-        },
-        "required": ["seconds", "source", "evidenceLevel", "confidence", "limitations"],
-        "additionalProperties": false
-      },
-      "AnalysisProjectionBestResults": {
-        "type": "object",
-        "properties": {
-          "current": { "type": "array", "maxItems": 16, "items": { "type": "object", "properties": { "semanticKey": { "type": ["string", "null"] }, "distance": { "type": "string" }, "seconds": { "type": ["integer", "null"] }, "date": { "type": ["string", "null"], "format": "date" }, "source": { "type": "string", "const": "user_claimed_legacy" }, "resultKind": { "type": "string", "const": "legacy_unspecified" }, "limitations": { "type": "array", "items": { "type": "string" } } }, "required": ["semanticKey", "distance", "seconds", "date", "source", "resultKind", "limitations"], "additionalProperties": false } },
-          "accepted": { "type": "array", "maxItems": 16, "items": { "type": "object", "properties": { "semanticKey": { "type": "string" }, "resultKind": { "type": "string", "enum": ["observed_moving", "observed_elapsed", "official_chip", "official_gun", "manual"] }, "seconds": { "type": "integer", "minimum": 1 } }, "required": ["semanticKey", "resultKind", "seconds"], "additionalProperties": false } },
-          "derivedBestKnown": { "type": "array", "maxItems": 16, "items": { "type": "object", "properties": { "semanticKey": { "type": "string" }, "raceResultId": { "type": ["string", "null"], "format": "uuid" }, "resultKind": { "type": "string", "enum": ["observed_moving", "observed_elapsed", "official_chip", "official_gun", "manual"] }, "seconds": { "type": "integer", "minimum": 1 }, "date": { "type": ["string", "null"], "format": "date" }, "status": { "type": "string", "enum": ["detected", "improvement", "not_improvement", "not_comparable"] }, "evidenceLevel": { "type": "string", "enum": ["exact", "high_confidence", "provisional", "ambiguous", "unlinked", "invalidated", "unknown"] }, "confidence": { "type": "string", "enum": ["high", "medium", "low", "unknown"] }, "limitations": { "type": "array", "items": { "type": "string" } } }, "required": ["semanticKey", "raceResultId", "resultKind", "seconds", "date", "status", "evidenceLevel", "confidence", "limitations"], "additionalProperties": false } },
-          "manual": { "type": "array", "maxItems": 16, "items": { "type": "object", "properties": { "sport": { "type": "string", "enum": ["run", "ride", "swim"] }, "distanceMeters": { "type": "integer", "minimum": 1 }, "seconds": { "type": "integer", "minimum": 1 }, "actualDate": { "type": "string", "format": "date" } }, "required": ["sport", "distanceMeters", "seconds", "actualDate"], "additionalProperties": false } },
-          "omittedCount": { "type": "integer", "minimum": 0 }
-        },
-        "required": ["current", "accepted", "derivedBestKnown", "manual", "omittedCount"],
         "additionalProperties": false
       },
       "MeResponse": {
@@ -1425,13 +1681,13 @@
             "type": "string",
             "enum": [
               "profile",
-              "goals",
               "rules"
-            ]
+            ],
+            "description": "Goals and results use previewGoalResultChange."
           },
           "structured": {
-            "$ref": "#/components/schemas/ProfileMemoryStructuredInput",
-            "description": "Required. Send only the object matching section. For goals, send a flat items list with optional exact ISO date, goal, target result, and comment; the server builds canonical goals text."
+            "$ref": "#/components/schemas/ProfileMemoryWritableStructuredInput",
+            "description": "Rules/profile input only. Goals and results use the dedicated goals-results operations."
           },
           "previousHash": {
             "type": "string",
@@ -3220,6 +3476,1221 @@
           }
         },
         "additionalProperties": true
+      },
+      "GoalResultEditCommand": {
+        "oneOf": [
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "const": "general_create"
+              },
+              "operationId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "title": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 300
+              },
+              "deadlineDate": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "sport": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "run",
+                      "ride",
+                      "swim"
+                    ]
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "target": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 500
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "comment": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 1000
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "type",
+              "operationId",
+              "title"
+            ]
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "const": "general_update"
+              },
+              "operationId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "goalPublicId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "title": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 300
+              },
+              "deadlineDate": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "sport": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "run",
+                      "ride",
+                      "swim"
+                    ]
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "target": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 500
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "comment": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 1000
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "type",
+              "operationId",
+              "goalPublicId"
+            ]
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "const": "general_archive"
+              },
+              "operationId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "goalPublicId": {
+                "type": "string",
+                "format": "uuid"
+              }
+            },
+            "required": [
+              "type",
+              "operationId",
+              "goalPublicId"
+            ]
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "const": "start_create"
+              },
+              "operationId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "title": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 300
+              },
+              "date": {
+                "type": "string",
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+              },
+              "timezone": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 100
+              },
+              "sport": {
+                "type": "string",
+                "enum": [
+                  "run",
+                  "ride",
+                  "swim"
+                ]
+              },
+              "distanceMeters": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 1000000
+              },
+              "priority": {
+                "type": "string",
+                "enum": [
+                  "A",
+                  "B",
+                  "C"
+                ]
+              },
+              "target": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 500
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "comment": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 1000
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "type",
+              "operationId",
+              "title",
+              "date",
+              "sport",
+              "distanceMeters",
+              "priority"
+            ]
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "const": "start_update"
+              },
+              "operationId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "goalPublicId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "title": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 300
+              },
+              "date": {
+                "type": "string",
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+              },
+              "timezone": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 100
+              },
+              "sport": {
+                "type": "string",
+                "enum": [
+                  "run",
+                  "ride",
+                  "swim"
+                ]
+              },
+              "distanceMeters": {
+                "anyOf": [
+                  {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 1000000
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "priority": {
+                "type": "string",
+                "enum": [
+                  "A",
+                  "B",
+                  "C"
+                ]
+              },
+              "target": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 500
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "comment": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 1000
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "type",
+              "operationId",
+              "goalPublicId"
+            ]
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "const": "start_delete"
+              },
+              "operationId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "goalPublicId": {
+                "type": "string",
+                "format": "uuid"
+              }
+            },
+            "required": [
+              "type",
+              "operationId",
+              "goalPublicId"
+            ]
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "const": "start_cancel"
+              },
+              "operationId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "goalPublicId": {
+                "type": "string",
+                "format": "uuid"
+              }
+            },
+            "required": [
+              "type",
+              "operationId",
+              "goalPublicId"
+            ]
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "const": "start_dns"
+              },
+              "operationId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "goalPublicId": {
+                "type": "string",
+                "format": "uuid"
+              }
+            },
+            "required": [
+              "type",
+              "operationId",
+              "goalPublicId"
+            ]
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "const": "result_set"
+              },
+              "operationId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "goalPublicId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "resultKind": {
+                "type": "string",
+                "enum": [
+                  "manual",
+                  "official_chip",
+                  "official_gun"
+                ]
+              },
+              "seconds": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 604800
+              },
+              "actualDate": {
+                "type": "string",
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+              }
+            },
+            "required": [
+              "type",
+              "operationId",
+              "goalPublicId",
+              "resultKind",
+              "seconds"
+            ]
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "const": "result_link_activity"
+              },
+              "operationId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "goalPublicId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "selectionId": {
+                "type": "string",
+                "pattern": "^[0-9a-f]{64}$"
+              }
+            },
+            "required": [
+              "type",
+              "operationId",
+              "goalPublicId",
+              "selectionId"
+            ]
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "const": "result_detach_activity"
+              },
+              "operationId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "goalPublicId": {
+                "type": "string",
+                "format": "uuid"
+              }
+            },
+            "required": [
+              "type",
+              "operationId",
+              "goalPublicId"
+            ]
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "const": "manual_result_create"
+              },
+              "operationId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "sport": {
+                "type": "string",
+                "enum": [
+                  "run",
+                  "ride",
+                  "swim"
+                ]
+              },
+              "distanceMeters": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 1000000
+              },
+              "seconds": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 604800
+              },
+              "actualDate": {
+                "type": "string",
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+              }
+            },
+            "required": [
+              "type",
+              "operationId",
+              "sport",
+              "distanceMeters",
+              "seconds",
+              "actualDate"
+            ]
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "const": "manual_result_update"
+              },
+              "operationId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "resultPublicId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "sport": {
+                "type": "string",
+                "enum": [
+                  "run",
+                  "ride",
+                  "swim"
+                ]
+              },
+              "distanceMeters": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 1000000
+              },
+              "seconds": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 604800
+              },
+              "actualDate": {
+                "type": "string",
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+              }
+            },
+            "required": [
+              "type",
+              "operationId",
+              "resultPublicId",
+              "sport",
+              "distanceMeters",
+              "seconds",
+              "actualDate"
+            ]
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "const": "manual_result_delete"
+              },
+              "operationId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "resultPublicId": {
+                "type": "string",
+                "format": "uuid"
+              }
+            },
+            "required": [
+              "type",
+              "operationId",
+              "resultPublicId"
+            ]
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "const": "legacy_result_convert"
+              },
+              "operationId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "expectedBestResultVersion": {
+                "type": "string",
+                "pattern": "^[0-9a-f]{64}$"
+              },
+              "legacyToken": {
+                "type": "string",
+                "pattern": "^[0-9a-f]{64}$"
+              },
+              "sport": {
+                "type": "string",
+                "enum": [
+                  "run",
+                  "ride",
+                  "swim"
+                ]
+              },
+              "distanceMeters": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 1000000
+              },
+              "seconds": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 604800
+              },
+              "actualDate": {
+                "type": "string",
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+              }
+            },
+            "required": [
+              "type",
+              "operationId",
+              "expectedBestResultVersion",
+              "legacyToken",
+              "sport",
+              "distanceMeters",
+              "seconds",
+              "actualDate"
+            ]
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "const": "legacy_result_delete"
+              },
+              "operationId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "expectedBestResultVersion": {
+                "type": "string",
+                "pattern": "^[0-9a-f]{64}$"
+              },
+              "legacyToken": {
+                "type": "string",
+                "pattern": "^[0-9a-f]{64}$"
+              }
+            },
+            "required": [
+              "type",
+              "operationId",
+              "expectedBestResultVersion",
+              "legacyToken"
+            ]
+          }
+        ]
+      },
+      "EditableGoalsResultsResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "version": {
+            "const": 2
+          },
+          "dataVersion": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "publicId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "kind": {
+                  "type": "string",
+                  "enum": [
+                    "general",
+                    "event"
+                  ]
+                },
+                "title": {
+                  "type": "string"
+                },
+                "target": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "comment": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "plannedDate": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "actualDate": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "timezone": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "sport": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "enum": [
+                        "run",
+                        "ride",
+                        "swim"
+                      ]
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "distanceMeters": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "priority": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "enum": [
+                        "A",
+                        "B",
+                        "C"
+                      ]
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "lifecycle": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "syncState": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "raceResult": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "bestResultSuggestion": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "publicId",
+                "kind",
+                "title"
+              ]
+            }
+          },
+          "omittedCount": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "bestResultVersion": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          },
+          "manualResults": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "legacyResults": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        },
+        "required": [
+          "version",
+          "dataVersion",
+          "items",
+          "omittedCount",
+          "bestResultVersion",
+          "manualResults",
+          "legacyResults"
+        ]
+      },
+      "GoalResultChangePreviewResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "ok": {
+            "const": true
+          },
+          "preview": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "changeId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "operation": {
+                "type": "string"
+              },
+              "expiresAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "confirmationRequired": {
+                "const": true
+              },
+              "summary": {
+                "type": "string"
+              },
+              "effects": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "before": {},
+              "after": {}
+            },
+            "required": [
+              "changeId",
+              "operation",
+              "expiresAt",
+              "confirmationRequired",
+              "summary",
+              "effects",
+              "before",
+              "after"
+            ]
+          }
+        },
+        "required": [
+          "ok",
+          "preview"
+        ]
+      },
+      "GoalResultChangeCommitResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "ok": {
+            "const": true
+          },
+          "changeId": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "replay": {
+            "type": "boolean"
+          },
+          "state": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "version": {
+                "const": 2
+              },
+              "dataVersion": {
+                "type": "string",
+                "pattern": "^[0-9a-f]{64}$"
+              },
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "publicId": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "kind": {
+                      "type": "string",
+                      "enum": [
+                        "general",
+                        "event"
+                      ]
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "target": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "comment": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "plannedDate": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "actualDate": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "timezone": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "sport": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "run",
+                            "ride",
+                            "swim"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "distanceMeters": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "priority": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "A",
+                            "B",
+                            "C"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "lifecycle": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "syncState": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "raceResult": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "bestResultSuggestion": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "publicId",
+                    "kind",
+                    "title"
+                  ]
+                }
+              },
+              "omittedCount": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "bestResultVersion": {
+                "type": "string",
+                "pattern": "^[0-9a-f]{64}$"
+              },
+              "manualResults": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              },
+              "legacyResults": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            },
+            "required": [
+              "version",
+              "dataVersion",
+              "items",
+              "omittedCount",
+              "bestResultVersion",
+              "manualResults",
+              "legacyResults"
+            ]
+          }
+        },
+        "required": [
+          "ok",
+          "changeId",
+          "replay",
+          "state"
+        ]
+      },
+      "GoalActivityCandidatesResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "goalPublicId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        },
+        "required": [
+          "goalPublicId",
+          "items"
+        ]
+      },
+      "ProfileMemoryWritableStructuredInput": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "rules": {
+            "$ref": "#/components/schemas/ProfileMemoryStructuredRules"
+          },
+          "profile": {
+            "$ref": "#/components/schemas/ProfileMemoryStructuredProfile"
+          }
+        }
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,24 +36,42 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
-        "debug": "^4.4.0",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -257,9 +275,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -468,9 +486,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -490,36 +508,30 @@
       }
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/http-errors/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -527,6 +539,10 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/inherits": {
@@ -587,12 +603,12 @@
       }
     },
     "node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
+      "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
       "license": "MIT",
       "dependencies": {
-        "jwa": "^1.4.1",
+        "jwa": "^1.4.2",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -786,9 +802,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -939,13 +955,14 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -965,36 +982,19 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
-      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.7.0",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/raw-body/node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/router": {
@@ -1100,15 +1100,15 @@
       "peer": true
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -1120,14 +1120,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1211,18 +1211,36 @@
       "license": "MIT"
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/unpipe": {

--- a/scripts/test-openapi-contract.js
+++ b/scripts/test-openapi-contract.js
@@ -20,6 +20,10 @@ const expectedActionsPaths = [
   '/gw/api/db/trainings',
   '/gw/api/db/activity_detail',
   '/gw/api/db/goals/current',
+  '/gw/api/db/goals/editable',
+  '/gw/api/db/goals/activity-candidates',
+  '/gw/api/db/goals/changes/preview',
+  '/gw/api/db/goals/changes/commit',
   '/gw/api/db/profile_sections',
   '/gw/api/db/profile_sections/preview',
   '/gw/api/db/profile_sections/commit',
@@ -34,7 +38,7 @@ const expectedActionsPaths = [
 // Frozen from the P08 AnalysisProjection interfaces and the P11 bridge-route
 // fixture in stas.run. This covers every nested response field, type,
 // nullability, enum, required list, and additionalProperties boundary.
-const expectedAnalysisProjectionSchemaHash = 'bc28e3554610b7725eda461e0022482bcbc04704a4446be4a872c92e53c62268';
+const expectedAnalysisProjectionSchemaHash = '9b00379357673a5c64c567e939728e75686e54dd6bfa0846a36e83aba6445b6c';
 const analysisProjectionSchemaNames = [
   'AnalysisProjectionResponse',
   'AnalysisProjectionItem',
@@ -152,7 +156,7 @@ async function main() {
   }
 
   const pathNames = Object.keys(gatewaySchema.paths || {});
-  assert.equal(pathNames.length, expectedActionsPaths.length, 'canonical schema must expose exactly 14 Actions paths');
+  assert.equal(pathNames.length, expectedActionsPaths.length, 'canonical schema must expose exactly 18 Actions paths');
   assert.deepEqual(
     [...pathNames].sort(),
     [...expectedActionsPaths].sort(),
@@ -192,6 +196,19 @@ async function main() {
     '/gw/api/db/trainings must document the runtime bare-array response'
   );
 
+  const editableGoals = gatewaySchema.paths['/gw/api/db/goals/editable'];
+  assert.deepEqual(Object.keys(editableGoals), ['get'], 'editable goals must stay GET-only');
+  assert.equal(editableGoals.get.operationId, 'getEditableGoalsResults');
+  assert.equal(
+    editableGoals.get.responses['200'].content['application/json'].schema.$ref,
+    '#/components/schemas/EditableGoalsResultsResponse',
+  );
+  const previewGoalResult = gatewaySchema.paths['/gw/api/db/goals/changes/preview'].post;
+  const commitGoalResult = gatewaySchema.paths['/gw/api/db/goals/changes/commit'].post;
+  assert.equal(previewGoalResult.operationId, 'previewGoalResultChange');
+  assert.equal(commitGoalResult.operationId, 'commitGoalResultChange');
+  assert.equal(gatewaySchema.components.schemas.GoalResultEditCommand.oneOf.length, 16);
+
   const currentGoals = gatewaySchema.paths['/gw/api/db/goals/current'];
   assert.deepEqual(Object.keys(currentGoals), ['get'], '/gw/api/db/goals/current must stay GET-only');
   assert.equal(currentGoals.get.security, undefined, 'current goals must inherit the adjacent OAuth2 security requirement');
@@ -202,7 +219,6 @@ async function main() {
   );
   const currentProjection = gatewaySchema.components.schemas.AnalysisProjectionResponse;
   assert.equal(currentProjection.properties.items.maxItems, 16, 'current goals items must be capped at 16');
-  assert.match(currentProjection.description, /12 KB UTF-8/, 'current goals must document the runtime 12 KB UTF-8 bound');
   const frozenAnalysisProjectionSchema = Object.fromEntries(analysisProjectionSchemaNames.map((name) => [
     name,
     gatewaySchema.components.schemas[name],

--- a/scripts/test-openapi-contract.js
+++ b/scripts/test-openapi-contract.js
@@ -18,7 +18,6 @@ const expectedActionsPaths = [
   '/gw/api/me',
   '/gw/api/db/user_summary',
   '/gw/api/db/activity_detail',
-  '/gw/api/db/goals/current',
   '/gw/api/db/goals/editable',
   '/gw/api/db/goals/activity-candidates',
   '/gw/api/db/goals/changes/preview',
@@ -27,23 +26,12 @@ const expectedActionsPaths = [
   '/gw/api/db/profile_sections/preview',
   '/gw/api/db/profile_sections/commit',
   '/gw/api/db/profile_changes',
+  '/gw/api/db/profile_changes/{changeId}',
   '/gw/api/db/profile_changes/{changeId}/restore',
   '/gw/icu/events',
   '/gw/trainings',
   '/gw/api/db/user_summary/v2',
   '/gw/strategy',
-];
-
-// Frozen from the P08 AnalysisProjection interfaces and the P11 bridge-route
-// fixture in stas.run. This covers every nested response field, type,
-// nullability, enum, required list, and additionalProperties boundary.
-const expectedAnalysisProjectionSchemaHash = 'bc28e3554610b7725eda461e0022482bcbc04704a4446be4a872c92e53c62268';
-const analysisProjectionSchemaNames = [
-  'AnalysisProjectionResponse',
-  'AnalysisProjectionItem',
-  'AnalysisProjectionResults',
-  'AnalysisProjectionResultLane',
-  'AnalysisProjectionBestResults',
 ];
 
 function sha256(buffer) {
@@ -200,26 +188,55 @@ async function main() {
   assert.equal(previewGoalResult.operationId, 'previewGoalResultChange');
   assert.equal(commitGoalResult.operationId, 'commitGoalResultChange');
   assert.equal(gatewaySchema.components.schemas.GoalResultEditCommand.oneOf.length, 16);
+  assert.equal(gatewaySchema.paths['/gw/api/db/goals/current'], undefined, 'retired current-goals path must stay absent');
+  assert.equal(gatewaySchema.components.schemas.AnalysisProjectionResponse, undefined);
 
-  const currentGoals = gatewaySchema.paths['/gw/api/db/goals/current'];
-  assert.deepEqual(Object.keys(currentGoals), ['get'], '/gw/api/db/goals/current must stay GET-only');
-  assert.equal(currentGoals.get.security, undefined, 'current goals must inherit the adjacent OAuth2 security requirement');
+  const commandTypes = gatewaySchema.components.schemas.GoalResultEditCommand.oneOf
+    .flatMap((variant) => variant.properties.type.enum)
+    .sort();
+  assert.deepEqual(commandTypes, [
+    'general_archive',
+    'general_create',
+    'general_update',
+    'legacy_result_convert',
+    'legacy_result_delete',
+    'manual_result_create',
+    'manual_result_delete',
+    'manual_result_update',
+    'result_detach_activity',
+    'result_link_activity',
+    'result_set',
+    'start_cancel',
+    'start_create',
+    'start_delete',
+    'start_dns',
+    'start_update',
+  ]);
+
+  const profileSections = gatewaySchema.paths['/gw/api/db/profile_sections'].get;
+  const activeProfileSection = profileSections.responses['200'].content['application/json']
+    .schema.properties.sections.items.$ref;
+  assert.equal(activeProfileSection, '#/components/schemas/ActiveProfileSection');
+  assert.deepEqual(gatewaySchema.components.schemas.ActiveProfileSection.properties.section.enum, ['profile', 'rules']);
+  assert.equal(gatewaySchema.components.schemas.ProfileMemoryStructuredGoals, undefined);
+
+  const profilePreview = gatewaySchema.paths['/gw/api/db/profile_sections/preview'].post;
   assert.equal(
-    currentGoals.get.responses['200'].content['application/json'].schema.$ref,
-    '#/components/schemas/AnalysisProjectionResponse',
-    'current goals must document the exact bounded P08 projection'
+    profilePreview.responses['200'].content['application/json'].schema.$ref,
+    '#/components/schemas/ProfileSectionPreviewResult'
   );
-  const currentProjection = gatewaySchema.components.schemas.AnalysisProjectionResponse;
-  assert.equal(currentProjection.properties.items.maxItems, 16, 'current goals items must be capped at 16');
-  const frozenAnalysisProjectionSchema = Object.fromEntries(analysisProjectionSchemaNames.map((name) => [
-    name,
-    gatewaySchema.components.schemas[name],
-  ]));
+  assert.match(profilePreview.description, /noChange=true/);
+
+  const profileHistory = gatewaySchema.paths['/gw/api/db/profile_changes'].get;
+  assert.equal(profileHistory.operationId, 'readProfileChangeHistory');
   assert.equal(
-    sha256(Buffer.from(stableStringify(frozenAnalysisProjectionSchema))),
-    expectedAnalysisProjectionSchemaHash,
-    'current goals must keep the exact frozen P08/P11 bounded response contract'
+    profileHistory.responses['200'].content['application/json'].schema.$ref,
+    '#/components/schemas/ProfileMemoryHistoryPage'
   );
+  assert.equal(profileHistory.parameters.find((parameter) => parameter.name === 'limit').schema.maximum, 20);
+  assert.ok(profileHistory.parameters.some((parameter) => parameter.name === 'cursor'));
+  const profileDetail = gatewaySchema.paths['/gw/api/db/profile_changes/{changeId}'].get;
+  assert.equal(profileDetail.operationId, 'readProfileChangeDetail');
 
   const gwTrainings = gatewaySchema.paths['/gw/trainings'].get;
   assert.equal(gwTrainings.operationId, 'getTrainings');

--- a/scripts/test-openapi-contract.js
+++ b/scripts/test-openapi-contract.js
@@ -17,7 +17,6 @@ const productSchemaPath = process.env.STAS_PRODUCT_ACTIONS_SCHEMA
 const expectedActionsPaths = [
   '/gw/api/me',
   '/gw/api/db/user_summary',
-  '/gw/api/db/trainings',
   '/gw/api/db/activity_detail',
   '/gw/api/db/goals/current',
   '/gw/api/db/goals/editable',
@@ -38,7 +37,7 @@ const expectedActionsPaths = [
 // Frozen from the P08 AnalysisProjection interfaces and the P11 bridge-route
 // fixture in stas.run. This covers every nested response field, type,
 // nullability, enum, required list, and additionalProperties boundary.
-const expectedAnalysisProjectionSchemaHash = '9b00379357673a5c64c567e939728e75686e54dd6bfa0846a36e83aba6445b6c';
+const expectedAnalysisProjectionSchemaHash = 'bc28e3554610b7725eda461e0022482bcbc04704a4446be4a872c92e53c62268';
 const analysisProjectionSchemaNames = [
   'AnalysisProjectionResponse',
   'AnalysisProjectionItem',
@@ -156,7 +155,7 @@ async function main() {
   }
 
   const pathNames = Object.keys(gatewaySchema.paths || {});
-  assert.equal(pathNames.length, expectedActionsPaths.length, 'canonical schema must expose exactly 18 Actions paths');
+  assert.equal(pathNames.length, expectedActionsPaths.length, 'canonical schema must expose exactly 17 Actions paths');
   assert.deepEqual(
     [...pathNames].sort(),
     [...expectedActionsPaths].sort(),
@@ -188,13 +187,6 @@ async function main() {
 
   const badRequiredReferences = findBadRequiredReferences(gatewaySchema);
   assert.deepEqual(badRequiredReferences, [], 'object schemas must not require missing properties');
-
-  const dbTrainings = gatewaySchema.paths['/gw/api/db/trainings'].get;
-  assert.equal(
-    dbTrainings.responses['200'].content['application/json'].schema.$ref,
-    '#/components/schemas/TrainingsListResponse',
-    '/gw/api/db/trainings must document the runtime bare-array response'
-  );
 
   const editableGoals = gatewaySchema.paths['/gw/api/db/goals/editable'];
   assert.deepEqual(Object.keys(editableGoals), ['get'], 'editable goals must stay GET-only');
@@ -230,6 +222,12 @@ async function main() {
   );
 
   const gwTrainings = gatewaySchema.paths['/gw/trainings'].get;
+  assert.equal(gwTrainings.operationId, 'getTrainings');
+  assert.equal(
+    gwTrainings.parameters.find((parameter) => parameter.name === 'full')?.schema?.default,
+    false,
+    '/gw/trainings must default to the compact index mode'
+  );
   assert.equal(
     gwTrainings.responses['200'].content['application/json'].schema.$ref,
     '#/components/schemas/TrainingsListResponse',
@@ -246,6 +244,11 @@ async function main() {
     stableStringify(gwTrainings).toLowerCase().includes('full raw'),
     false,
     '/gw/trainings descriptions must not promise full raw data'
+  );
+  assert.equal(
+    gatewaySchema.components.schemas.TrainingFull.properties.listDetail.$ref,
+    '#/components/schemas/TrainingListDetail',
+    'every training item must expose exact list-delivery accounting'
   );
   assert.equal(gatewaySchema.components.schemas.ErrorResponse.properties.retryable.type, 'boolean');
   assert.equal(gatewaySchema.components.schemas.ErrorResponse.properties.upstream_status.type, 'integer');


### PR DESCRIPTION
## Что изменено

- удалён старый current-goals Action;
- добавлены compact profile history и отдельное чтение детали;
- goal preview contract синхронизирован с приложением и MCP;
- OpenAPI сделан побайтово идентичным канонической схеме в STAS.run;
- обновлён lockfile для устранения четырёх транзитивных security advisories.

## Почему

Gateway должен выпускаться только вместе с соответствующим приложением: старый Action в production больше не является рабочим путём.

## Проверки

Прошли OAuth, bearer auth, delete safety, ICU POST, legacy aliases, DB proxy, agent auth, route order, OpenAPI contract, syntax checks и npm audit. Текущий npm audit: 0 advisories.