### PR TITLE
Fix wellness schema compatibility in GPT Builder

### DIFF
--- a/openapi.actions.json
+++ b/openapi.actions.json
@@ -1507,6 +1507,7 @@
       "WellnessCustomSeriesMap": {
         "type": "object",
         "description": "Custom Intervals.icu/source fields with original names preserved. If a unit or scale is unclear, do not invent it; describe only the observed trend or ask the user.",
+        "properties": {},
         "additionalProperties": {
           "$ref": "#/components/schemas/WellnessValueSeries"
         }
@@ -1514,16 +1515,10 @@
       "WellnessDateRange": {
         "type": "array",
         "description": "Two dates: inclusive oldest and exclusive newest.",
-        "prefixItems": [
-          {
-            "type": "string",
-            "format": "date"
-          },
-          {
-            "type": "string",
-            "format": "date"
-          }
-        ],
+        "items": {
+          "type": "string",
+          "format": "date"
+        },
         "minItems": 2,
         "maxItems": 2
       },

--- a/scripts/test-openapi-contract.js
+++ b/scripts/test-openapi-contract.js
@@ -409,6 +409,19 @@ async function main() {
     wellness.parameters.find((parameter) => parameter.name === 'newest').description.includes('No fixed day limit'),
     true,
   );
+  assert.deepEqual(
+    gatewaySchema.components.schemas.WellnessDateRange.items,
+    { type: 'string', format: 'date' },
+    'GPT Builder requires an items schema for wellness date-range arrays',
+  );
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(
+      gatewaySchema.components.schemas.WellnessCustomSeriesMap,
+      'properties',
+    ),
+    true,
+    'GPT Builder requires properties to be present for wellness custom-field objects',
+  );
 
   const userSummaryV2 = gatewaySchema.paths['/gw/api/db/user_summary/v2'].get;
   for (const pathItem of Object.values(gatewaySchema.paths)) {


### PR DESCRIPTION
Синхронизирует исправленную wellness Actions-схему с приложением и добавляет проверку требований GPT Builder.

Проверено: `npm run test:openapi-contract`; схемы приложения и gateway совпадают байт-в-байт.